### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 * @kyma-team
 
 # All .md files
-*.md @kazydek @mmitoraj
+*.md @kazydek @mmitoraj @bszwarc
 
 # Text constants file
-library/src/constants.ts @kazydek @mmitoraj
+library/src/constants.ts @kazydek @mmitoraj @bszwarc

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the "asyncapi-react" repository. The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @kyma-team
+* @asyncapi/kyma-team
 
 # All .md files
 *.md @kazydek @mmitoraj @bszwarc


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add Basia Szwarc as an additional TW code owner to have a backup as @mmitoraj is currently on maternity leave.
- Correct the existing code owners as the `kyma-team` was added without the organization and failed to work.