### PR TITLE
fix: fix relative links generation for github pages

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -2,6 +2,7 @@
   "name": "playground",
   "private": true,
   "description": "Playground app for AsyncApi React Component",
+  "homepage": "https://asyncapi.github.io/asyncapi-react",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Without this PR playground relative links are pointing to the root `<script src="/static/js/main.2b18fd69.chunk.js">`. Adding homepage makes generated links look like `<script src="/asyncapi-react/static/js/main.2b18fd69.chunk.js">`. It is all because link to GH page is with specific path, repo name: https://asyncapi.github.io/asyncapi-react