### PR TITLE
feat: Remove schema tables and use a fluent layout

### DIFF
--- a/library/src/containers/Schemas/Schema.tsx
+++ b/library/src/containers/Schemas/Schema.tsx
@@ -3,18 +3,14 @@ import React from 'react';
 import { SchemaPropertiesComponent as SchemaProperties } from './SchemaProperties';
 import { SchemaExampleComponent } from './SchemaExample';
 
-import { Table, Toggle } from '../../components';
+import { Toggle } from '../../components';
 import { Schema } from '../../types';
 import {
   bemClasses,
   searchForNestedObject,
   removeSpecialChars,
 } from '../../helpers';
-import {
-  SCHEMA_COLUMN_NAMES,
-  ITEM_LABELS,
-  CONTAINER_LABELS,
-} from '../../constants';
+import { ITEM_LABELS, CONTAINER_LABELS } from '../../constants';
 
 interface Props {
   name: string;
@@ -70,14 +66,8 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
 
   const content = (
     <>
-      <div className={bemClasses.element(`${className}-table`)}>
-        <Table
-          header={{
-            columns: SCHEMA_COLUMN_NAMES,
-          }}
-        >
-          {renderSchemaProps(name, schema)}
-        </Table>
+      <div className={`${bemClasses.element(`${className}-table`)} p-4`}>
+        {renderSchemaProps(name, schema)}
         <div className={bemClasses.element('additional-properties-notice')}>
           Additional properties are{' '}
           {schema.additionalProperties === false && 'NOT'} allowed.

--- a/library/src/containers/Schemas/SchemaProperties.tsx
+++ b/library/src/containers/Schemas/SchemaProperties.tsx
@@ -3,69 +3,13 @@ import merge from 'merge';
 
 import { bemClasses } from '../../helpers';
 import { TypeWithKey, Schema } from '../../types';
-import {
-  Markdown,
-  TableAccessor,
-  TableRow,
-  TreeSpace,
-  TreeLeaf,
-} from '../../components';
+import { Markdown, TreeSpace, TreeLeaf } from '../../components';
 
 type SchemaWithKey = TypeWithKey<string, Schema>;
 interface SchemaElement {
   schema: SchemaWithKey;
   treeSpace: number;
 }
-
-const schemaPropertiesAccessors: Array<TableAccessor<SchemaElement>> = [
-  el => (
-    <>
-      {(() => {
-        const treeSpaces = [];
-        if (el.treeSpace) {
-          for (let i = 0; i < el.treeSpace; i++) {
-            treeSpaces.push(<TreeSpace key={i} />);
-          }
-          treeSpaces.push(<TreeLeaf key={el.treeSpace} />);
-        }
-        return treeSpaces;
-      })()}
-      {el.schema.key}
-    </>
-  ),
-  el => <span>{el.schema.content.title}</span>,
-  el => (
-    <span>
-      {el.schema.content.type}
-      {el.schema.content.anyOf ? ` ${el.schema.content.anyOf}` : ''}
-      {el.schema.content.oneOf ? ` ${el.schema.content.oneOf}` : ''}
-      {el.schema.content.items && el.schema.content.items.type
-        ? ` (${el.schema.content.items.type})`
-        : ''}
-    </span>
-  ),
-  el => <span>{el.schema.content.format}</span>,
-  el => <span>{el.schema.content.default}</span>,
-  el => {
-    const enumElements = getEnumHTMLElements(el.schema);
-    return (
-      <div>
-        {el.schema.content.description && (
-          <Markdown>{el.schema.content.description}</Markdown>
-        )}
-        {enumElements.length > 0 && <div>Enum: {enumElements}</div>}
-        {el.schema.content.pattern && (
-          <div>
-            Must Match{' '}
-            <span className={bemClasses.element(`pattern`)}>
-              {el.schema.content.pattern}
-            </span>
-          </div>
-        )}
-      </div>
-    );
-  },
-];
 
 const getEnumHTMLElements = (schema: SchemaWithKey): HTMLElement[] => {
   let enumElements: any[] = [];
@@ -151,6 +95,47 @@ interface Props {
   description?: React.ReactNode;
 }
 
+const renderPropertyName = (el: SchemaElement): React.ReactNode => (
+  <>
+    {(() => {
+      const treeSpaces = [];
+      if (el.treeSpace) {
+        for (let i = 0; i < el.treeSpace; i++) {
+          treeSpaces.push(<TreeSpace key={i} />);
+        }
+        treeSpaces.push(<TreeLeaf key={el.treeSpace} />);
+      }
+      return treeSpaces;
+    })()}
+    {el.schema.key}
+  </>
+);
+
+const renderPropertyDescription = (el: SchemaElement): React.ReactNode => {
+  const enumElements = getEnumHTMLElements(el.schema);
+  return (
+    <div>
+      {el.schema.content.description && (
+        <Markdown>{el.schema.content.description}</Markdown>
+      )}
+      {enumElements.length > 0 && <div>Enum: {enumElements}</div>}
+      {el.schema.content.pattern && (
+        <div>
+          Must Match{' '}
+          <span className={bemClasses.element(`pattern`)}>
+            {el.schema.content.pattern}
+          </span>
+        </div>
+      )}
+      {el.schema.content.default && (
+        <div>
+          Default: <span>{el.schema.content.default}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const SchemaPropertiesComponent: React.FunctionComponent<Props> = ({
   name,
   properties,
@@ -167,12 +152,37 @@ export const SchemaPropertiesComponent: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <>
-      <TableRow accessors={schemaPropertiesAccessors} element={element} />
+    <div>
+      <div className="flex py-2">
+        <div className="flex-1">{renderPropertyName(element)}</div>
+        <div className="flex-1">
+          <span className="capitalize text-sm text-teal font-bold">
+            {element.schema.content.type}
+            {element.schema.content.anyOf
+              ? ` ${element.schema.content.anyOf}`
+              : ''}
+            {element.schema.content.oneOf
+              ? ` ${element.schema.content.oneOf}`
+              : ''}
+            {element.schema.content.items && element.schema.content.items.type
+              ? ` (${element.schema.content.items.type})`
+              : ''}
+          </span>
+          {element.schema.content.format && (
+            <span
+              className="bg-yellow-dark font-bold no-underline text-black rounded lowercase ml-2"
+              style={{ height: '20px', fontSize: '11px', padding: '3px' }}
+            >
+              {element.schema.content.format}
+            </span>
+          )}
+          <div className="py-2">{renderPropertyDescription(element)}</div>
+        </div>
+      </div>
       {renderOf(space, alteredProperties.anyOf)}
       {renderOf(space, alteredProperties.oneOf)}
       {renderProperties(alteredProperties, space)}
       {renderItems(alteredProperties, space)}
-    </>
+    </div>
   );
 };

--- a/library/src/containers/Schemas/SchemaProperties.tsx
+++ b/library/src/containers/Schemas/SchemaProperties.tsx
@@ -119,14 +119,6 @@ const renderPropertyDescription = (el: SchemaElement): React.ReactNode => {
         <Markdown>{el.schema.content.description}</Markdown>
       )}
       {enumElements.length > 0 && <div>Enum: {enumElements}</div>}
-      {el.schema.content.pattern && (
-        <div>
-          Must Match{' '}
-          <span className={bemClasses.element(`pattern`)}>
-            {el.schema.content.pattern}
-          </span>
-        </div>
-      )}
       {el.schema.content.default && (
         <div>
           Default: <span>{el.schema.content.default}</span>
@@ -174,6 +166,14 @@ export const SchemaPropertiesComponent: React.FunctionComponent<Props> = ({
               style={{ height: '20px', fontSize: '11px', padding: '3px' }}
             >
               {element.schema.content.format}
+            </span>
+          )}
+          {element.schema.content.pattern && (
+            <span
+              className="bg-purple-dark font-bold no-underline text-white rounded normal-case ml-2"
+              style={{ height: '20px', fontSize: '11px', padding: '3px' }}
+            >
+              must match {element.schema.content.pattern}
             </span>
           )}
           <div className="py-2">{renderPropertyDescription(element)}</div>

--- a/library/src/styles/fiori.css
+++ b/library/src/styles/fiori.css
@@ -62,8 +62,14 @@
 .lowercase {
   text-transform: lowercase;
 }
+.normal-case {
+  text-transform: none;
+}
 .text-black {
   color: #22292f;
+}
+.text-white {
+  color: #fff;
 }
 .ml-2 {
   margin-left: 0.5rem;
@@ -73,6 +79,9 @@
 }
 .bg-yellow-dark {
   background-color: #f2d024;
+}
+.bg-purple-dark {
+  background-color: #794acf;
 }
 
 /* CURRENT THEME BASED ON KYMA STYLES */
@@ -1333,16 +1342,6 @@
   margin-left: 0.25rem;
   padding: 0 0.5rem;
   color: #f6993f;
-}
-
-.asyncapi__pattern {
-  line-height: 2;
-  background-color: #794acf;
-  font-weight: bold;
-  border-radius: 0.25rem;
-  margin-left: 0.25rem;
-  padding: 0 0.5rem;
-  color: #fff;
 }
 
 .asyncapi__additional-properties-notice {

--- a/library/src/styles/fiori.css
+++ b/library/src/styles/fiori.css
@@ -1,3 +1,82 @@
+/*
+  STYLES:
+    - Tailwind Helpers
+    - Fiori theme
+*/
+
+/*
+  These are some rules from Tailwind CSS.
+  The purpose is to help with a future migration, where this file will
+  probably be replaced by Tailwind CSS file.
+*/
+
+.capitalize {
+  text-transform: capitalize;
+}
+.text-sm {
+  font-size: 0.875rem;
+}
+.text-teal {
+  color: #4dc0b5;
+}
+.font-bold {
+  font-weight: 700;
+}
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+.p-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.p-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.flex {
+  display: flex;
+}
+.flex-1 {
+  flex: 1 1 0%;
+}
+.no-underline {
+  text-decoration: none;
+}
+.lowercase {
+  text-transform: lowercase;
+}
+.text-black {
+  color: #22292f;
+}
+.ml-2 {
+  margin-left: 0.5rem;
+}
+.rounded {
+  border-radius: 0.25rem;
+}
+.bg-yellow-dark {
+  background-color: #f2d024;
+}
+
+/* CURRENT THEME BASED ON KYMA STYLES */
+
 .asyncapi {
   font-family: '72';
   font-size: 14px;


### PR DESCRIPTION
This removes the usage of tables to describe schemas. Tables are a terrible way to display information with lots of optional fields, which is our case. Instead, I'm using a "fluent" layout similar to the one we use in the [HTML template](https://www.github.com/asyncapi/html-template).

### Showcase
![Screenshot 2020-08-11 at 18 43 15](https://user-images.githubusercontent.com/242119/89924599-8a815b00-dc02-11ea-935e-c42c357be3e0.png)


Fixes #95 