### PR TITLE
fix: error complains clickedItem is undefined

### DIFF
--- a/library/src/components/Toggle.tsx
+++ b/library/src/components/Toggle.tsx
@@ -59,6 +59,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (
+      clickedItem &&
       clickedItem.scroll &&
       clickedItem.state &&
       clickedItem.label === label
@@ -80,7 +81,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
 
     // for collapsing items in container when container will collapse
     if (
-      !clickedItem.state &&
+      !(clickedItem && clickedItem.state) &&
       ITEM_LABELS_VALUES.toString().includes(label) &&
       clickedItem.label === inContainer(label as ITEM_LABELS)
     ) {
@@ -88,7 +89,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
       return;
     }
 
-    if (!expanded && clickedItem.state && label) {
+    if (!expanded && clickedItem && clickedItem.state && label) {
       // for container when hash will change
       if (
         clickedItem.label === label &&


### PR DESCRIPTION
**Check for presence of `clickedItem`**

Otherwise it can result in `TypeError: clickedItem is undefined` as described in #107 

Changes proposed in this pull request:

- check for `clickedItem` presence before accessing it

**Related issue(s)**
Fixes #107 