### PR TITLE
fix: additional properties handling

### DIFF
--- a/library/src/helpers/beautifier.ts
+++ b/library/src/helpers/beautifier.ts
@@ -111,7 +111,10 @@ class Beautifier {
         if (prop.description) {
           prop.description = renderMd(prop.description as string);
         }
-        if (typeof prop.additionalProperties !== 'boolean') {
+        if (
+          typeof prop.additionalProperties === 'object' &&
+          prop.additionalProperties !== null
+        ) {
           const propAdditionalProperties: AdditionalProperties =
             prop.additionalProperties;
           const newPropAdditionalProperties: AdditionalProperties = {};

--- a/library/src/styles/fiori.css
+++ b/library/src/styles/fiori.css
@@ -418,6 +418,7 @@
 }
 
 .asyncapi__code-pre {
+  overflow-x: auto;
   margin: 0;
   font-size: 13px;
   padding: 12px;


### PR DESCRIPTION
When `additionalProperties` is an object, it was handling it incorrectly. It's fixed now. Also, took the opportunity to fix the CSS horizontal overflow on the examples.