### PR TITLE
fix: wrong toggle state

### DIFF
--- a/library/src/components/Toggle.tsx
+++ b/library/src/components/Toggle.tsx
@@ -82,7 +82,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
     // for collapsing items in container when container will collapse
     if (
       !(clickedItem && clickedItem.state) &&
-      ITEM_LABELS_VALUES.toString().includes(label) &&
+      ITEM_LABELS_VALUES.includes(label) &&
       clickedItem.label === inContainer(label as ITEM_LABELS)
     ) {
       setExpanded(false);
@@ -91,9 +91,10 @@ export const Toggle: React.FunctionComponent<Props> = ({
 
     if (!expanded && clickedItem && clickedItem.state && label) {
       // for container when hash will change
+      console.log(clickedItem);
       if (
         clickedItem.label === label &&
-        CONTAINER_LABELS_VALUES.toString().includes(label)
+        CONTAINER_LABELS_VALUES.includes(label)
       ) {
         setExpanded(true);
         return;

--- a/library/src/components/Toggle.tsx
+++ b/library/src/components/Toggle.tsx
@@ -91,7 +91,6 @@ export const Toggle: React.FunctionComponent<Props> = ({
 
     if (!expanded && clickedItem && clickedItem.state && label) {
       // for container when hash will change
-      console.log(clickedItem);
       if (
         clickedItem.label === label &&
         CONTAINER_LABELS_VALUES.includes(label)

--- a/library/src/constants.ts
+++ b/library/src/constants.ts
@@ -122,11 +122,11 @@ export enum CONTAINER_LABELS {
   MESSAGES = 'messages',
   SCHEMAS = 'schemas',
 }
-export const CONTAINER_LABELS_VALUES = Object.values(CONTAINER_LABELS);
+export const CONTAINER_LABELS_VALUES = Object.values<string>(CONTAINER_LABELS);
 export enum ITEM_LABELS {
   CHANNEL = 'channel',
   SERVER = 'server',
   MESSAGE = 'message',
   SCHEMA = 'schema',
 }
-export const ITEM_LABELS_VALUES = Object.values(ITEM_LABELS);
+export const ITEM_LABELS_VALUES = Object.values<string>(ITEM_LABELS);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Now, if user press any toggle, all the other toggles (in group - channels/messages etc) slide out. PR fixes this bug.