### PR TITLE
fix: improve markdown rendering of nested fields

### DIFF
--- a/library/src/helpers/beautifier.ts
+++ b/library/src/helpers/beautifier.ts
@@ -78,6 +78,10 @@ class Beautifier {
       return schema;
     }
 
+    if (schema.description) {
+      schema.description = renderMd(schema.description as string);
+    }
+
     if (schema.properties) {
       const properties = schema.properties;
       const newProperties: Record<string, Schema> = properties;
@@ -96,6 +100,9 @@ class Beautifier {
           }
 
           prop.properties = newPropProperties;
+        }
+        if (prop.items) {
+          prop.items = this.beautifySchema(prop.items);
         }
 
         newProperties[key] = prop;
@@ -133,6 +140,10 @@ class Beautifier {
       schema.additionalProperties = newAdditionalProperties;
     }
 
+    if (schema.items) {
+      schema.items = this.beautifySchema(schema.items);
+    }
+
     return schema;
   }
 
@@ -165,6 +176,7 @@ class Beautifier {
     }
     if (message.payload) {
       message.payload = this.resolveAllOf(message.payload);
+      message.payload = this.beautifySchema(message.payload);
     }
     if (message.headers) {
       message.headers = this.resolveAllOf(message.headers);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

We have some schemas that use nested fields and also array fields with markdown description. This was not correctly rendered before.

<details>
<summary>example-asyncapi.yaml</summary>

```yaml
asyncapi: 2.0.0
info:
  title: Test Records
  version: 0.21.1
channels:
  our-records:
    description: |
      A short description of what we are doing.

    subscribe:
      description: |
        **Important Information**

        Important Information for this subscription
      message:
        oneOf:
          - $ref: '#/components/messages/medicalAttendance'

components:
  messages:
    medicalAttendance:
      name: medicalAttendance
      title: Medical attendance records
      summary: Create or update a single medical attendance record.
      payload:
        type: object
        contentType: application/json
        title: MedicalAttendance
        description: |
          *(Something in italics)* - Something very important

          We describe some overall things about this message
        required:
          - type
        properties:
          type:
            title: Type of message
            type: string
            description: |
              *(Something in italics part two)* - The type of the whaterver:

                * `TYPE_A`: Something with As.
                * `TYPE_B`: Something with Bs. This includes looooong texts that
                  wrap into the next line.
                * ~~`TYPE_C`~~ _(deprecated)_: replaced by `TYPE_A`
            enum:
              - TYPE_A
              - TYPE_B
              - TYPE_C
          nestedd:
            type: object
            title: SOmething nested
            description: |
              *(Leistungserbringer)* - HealthCareProvider: A partner who is providing health care in a specific context.
            properties:
              fallbackName:
                type: string
                title: Fallback name
                description: |
                  *(TUUT)* - Some description
```
</details>

**Old:**
![image](https://user-images.githubusercontent.com/720821/94564831-c16e0780-0268-11eb-80a6-5452eaf86a90.png)

**New:**
![image](https://user-images.githubusercontent.com/720821/94564855-c632bb80-0268-11eb-8efb-123f7a0eb803.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
