### PR TITLE
fix: let the list of enums break into multiple lines

### DIFF
--- a/library/src/containers/Schemas/SchemaProperties.tsx
+++ b/library/src/containers/Schemas/SchemaProperties.tsx
@@ -15,9 +15,12 @@ const getEnumHTMLElements = (schema: SchemaWithKey): HTMLElement[] => {
   let enumElements: any[] = [];
   if (schema.content.enum && schema.content.enum.length) {
     enumElements = schema.content.enum.map((value: any, i: number) => (
-      <span className={bemClasses.element(`enum`)} key={i}>
-        "{value}"
-      </span>
+      <>
+        {' '}
+        <span className={bemClasses.element(`enum`)} key={i}>
+          "{value}"
+        </span>
+      </>
     ));
   }
 

--- a/library/src/styles/fiori.css
+++ b/library/src/styles/fiori.css
@@ -1356,7 +1356,6 @@
   border-color: #dae1e7;
   border-radius: 0.25rem;
   border-width: 1px;
-  margin-left: 0.25rem;
   padding: 0 0.5rem;
   color: #f6993f;
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

If we have a lot of enum values, the layout is broken because the enums are displayed in a single line. This can't be solved using CSS only, as there is no space between the enum values that the browser can break at. We add a spaced and remove the margin instead.

Before: 
![image](https://user-images.githubusercontent.com/648527/94905652-830d5e00-049d-11eb-8e16-f0b944e24372.png)

After:

![image](https://user-images.githubusercontent.com/648527/94905691-90c2e380-049d-11eb-9cb3-1b3f76664f23.png)

