### PR TITLE
feat: show title/name of message instead index in channel spec

### DIFF
--- a/library/src/containers/Channels/Channel.tsx
+++ b/library/src/containers/Channels/Channel.tsx
@@ -6,7 +6,7 @@ import { Parameters as ParametersComponent } from './Parameters';
 import { Badge, BadgeType, Toggle } from '../../components';
 import { bemClasses, removeSpecialChars } from '../../helpers';
 import { MESSAGE_TEXT, ITEM_LABELS, CONTAINER_LABELS } from '../../constants';
-import { Channel, isRawMessage, PayloadType } from '../../types';
+import { Channel, RawMessage, isRawMessage, PayloadType } from '../../types';
 
 interface Props {
   name: string;
@@ -25,6 +25,10 @@ export const ChannelComponent: React.FunctionComponent<Props> = ({
     CONTAINER_LABELS.CHANNELS,
     removeSpecialChars(name),
   ]);
+
+  const message =
+    (channel.publish && channel.publish.message) ||
+    (channel.subscribe && channel.subscribe.message);
 
   const oneOfPublish =
     channel.publish &&
@@ -92,7 +96,11 @@ export const ChannelComponent: React.FunctionComponent<Props> = ({
             className={bemClasses.element(`${className}-operations-header`)}
           >
             <h4>
-              <span>{MESSAGE_TEXT}</span>
+              <span>
+                {(message as RawMessage)?.title ||
+                  (message as RawMessage)?.name ||
+                  MESSAGE_TEXT}
+              </span>
             </h4>
           </header>
         )}

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -71,6 +71,8 @@ export const MessageComponent: React.FunctionComponent<Props> = ({
     );
   }
 
+  title = title || message.title || message.name;
+
   const summary = message.summary && (
     <div className={bemClasses.element(`${className}-summary`)}>
       <Markdown>{message.summary}</Markdown>

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -5,7 +5,7 @@ import { MessageComponent } from './Message';
 import { ExpandNestedConfig } from '../../config';
 import { bemClasses } from '../../helpers';
 import { Toggle } from '../../components';
-import { Message } from '../../types';
+import { Message, RawMessage } from '../../types';
 import { MESSAGES_TEXT, CONTAINER_LABELS } from '../../constants';
 
 interface Props {
@@ -36,17 +36,28 @@ export const MessagesComponent: React.FunctionComponent<Props> = ({
   const header = <h2>{MESSAGES_TEXT}</h2>;
   const content = (
     <ul className={bemClasses.element(`${className}-list`)}>
-      {Object.entries(messages).map(([key, message]) => (
-        <li key={key} className={bemClasses.element(`${className}-list-item`)}>
-          <MessageComponent
-            title={messagesLength < 2 && inChannel ? '' : key}
-            message={message}
-            hideTags={true}
-            inChannel={false}
-            toggleExpand={expand && expand.elements}
-          />
-        </li>
-      ))}
+      {Object.entries(messages).map(([key, message]) => {
+        const title =
+          messagesLength < 2 && inChannel
+            ? ''
+            : (message as RawMessage).title ||
+              (message as RawMessage).name ||
+              key;
+        return (
+          <li
+            key={key}
+            className={bemClasses.element(`${className}-list-item`)}
+          >
+            <MessageComponent
+              title={title}
+              message={message}
+              hideTags={true}
+              inChannel={false}
+              toggleExpand={expand && expand.elements}
+            />
+          </li>
+        );
+      })}
     </ul>
   );
 

--- a/library/src/styles/fiori.css
+++ b/library/src/styles/fiori.css
@@ -153,6 +153,7 @@
 
 .asyncapi__toggle-button {
   border: none;
+  background: none;
   height: 100%;
   cursor: pointer;
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

If channel message is described by `oneOf` or `anyOf` component render message's index instead title/name. This PR change behaviour. If single message has title, then render title, if title doesn't exist, then check name of message, finally render index.

**Example**

Modified spec from https://github.com/asyncapi/asyncapi-react/issues/140

```yaml

asyncapi: 2.0.0
info:
  title: Example project
  version: 1.0.0
servers:
  kafka:
    url: kafka:29092
    protocol: kafka
channels:
  another-topic:
    subscribe:
      message:
        oneOf:
        - name: io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto
          title: ExamplePayloadDto
          payload:
            "$ref": "#/components/schemas/ExamplePayloadDto"
        - payload:
            "$ref": "#/components/schemas/AnotherPayloadDto"
  example-topic:
    subscribe:
      message:
        name: io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto
        payload:
          "$ref": "#/components/schemas/ExamplePayloadDto"
components:
  schemas:
    ExamplePayloadDto:
      type: object
      properties:
        someString:
          type: string
        someLong:
          type: integer
          format: int64
        someEnum:
          type: string
          enum:
          - FOO1
          - FOO2
          - FOO3
      example:
        someString: string
        someLong: 0
        someEnum: FOO1
    AnotherPayloadDto:
      type: object
      properties:
        foo:
          type: string
        example:
          "$ref": "#/components/schemas/ExamplePayloadDto"
      example:
        foo: string
        example:
          someString: string
          someLong: 0
          someEnum: FOO1
```

Before:
![image](https://user-images.githubusercontent.com/20404945/94989330-45c7cf80-0574-11eb-8a68-624f019e0fd8.png)

After:
![image](https://user-images.githubusercontent.com/20404945/94989357-7ad42200-0574-11eb-90b1-247b039ca6e5.png)

**Related issue(s)**
Resolves https://github.com/asyncapi/asyncapi-react/issues/140
