### PR TITLE
fix: refresh state in playground by debounce

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -33,9 +33,7 @@ class Playground extends Component<{}, State> {
   state = {
     schema: defaultSchema,
     config: defaultConfig,
-    schemaFromEditor: defaultSchema,
     schemaFromExternalResource: '',
-    configFromEditor: defaultConfig,
     refreshing: false,
   };
 
@@ -111,7 +109,9 @@ class Playground extends Component<{}, State> {
   };
 
   private startRefreshing = (): void => {
-    this.setState({ refreshing: true });
+    setTimeout(() => {
+      this.setState({ refreshing: true });
+    }, 500);
   };
 
   private stopRefreshing = (): void => {

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -14,7 +14,7 @@ import {
   AsyncApiWrapper,
 } from './components';
 
-import { defaultConfig, parse } from './common';
+import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
 const defaultSchema = specs.streetlights;
@@ -25,16 +25,29 @@ interface State {
   schemaFromEditor: string;
   schemaFromExternalResource: string;
   configFromEditor: string;
+  timeout: number | undefined;
 }
 
 class Playground extends Component<{}, State> {
+  refreshFn: Function;
+
   state = {
     schema: defaultSchema,
     config: defaultConfig,
     schemaFromEditor: defaultSchema,
     schemaFromExternalResource: '',
     configFromEditor: defaultConfig,
+    timeout: undefined,
   };
+
+  constructor(props: any) {
+    super(props);
+    this.refreshFn = debounce(this.refreshState, this, 1000);
+  }
+
+  componentDidUpdate() {
+    this.refreshFn();
+  }
 
   render() {
     const {

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -25,7 +25,6 @@ interface State {
   schemaFromEditor: string;
   schemaFromExternalResource: string;
   configFromEditor: string;
-  timeout: number | undefined;
 }
 
 class Playground extends Component<{}, State> {
@@ -37,7 +36,6 @@ class Playground extends Component<{}, State> {
     schemaFromEditor: defaultSchema,
     schemaFromExternalResource: '',
     configFromEditor: defaultConfig,
-    timeout: undefined,
   };
 
   constructor(props: any) {

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -41,13 +41,13 @@ class Playground extends Component<{}, State> {
     super(props);
     this.updateSchemaFn = debounce(
       this.updateSchema,
-      500,
+      750,
       this.startRefreshing,
       this.stopRefreshing,
     );
     this.updateConfigFn = debounce(
       this.updateConfig,
-      500,
+      750,
       this.startRefreshing,
       this.stopRefreshing,
     );

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -22,9 +22,7 @@ const defaultSchema = specs.streetlights;
 interface State {
   schema: string;
   config: string;
-  schemaFromEditor: string;
   schemaFromExternalResource: string;
-  configFromEditor: string;
   refreshing: boolean;
 }
 
@@ -58,13 +56,7 @@ class Playground extends Component<{}, State> {
   }
 
   render() {
-    const {
-      schema,
-      config,
-      schemaFromEditor,
-      schemaFromExternalResource,
-      configFromEditor,
-    } = this.state;
+    const { schema, config, schemaFromExternalResource } = this.state;
     const parsedConfig = parse<ConfigInterface>(config || defaultConfig);
 
     return (
@@ -82,7 +74,7 @@ class Playground extends Component<{}, State> {
                   />
                   <CodeEditorComponent
                     key="Schema"
-                    code={schemaFromEditor}
+                    code={schema}
                     externalResource={schemaFromExternalResource}
                     parentCallback={this.updateSchemaFn}
                     mode="text/yaml"
@@ -92,7 +84,7 @@ class Playground extends Component<{}, State> {
               <Tab title="Configuration" key="Configuration">
                 <CodeEditorComponent
                   key="Configuration"
-                  code={configFromEditor}
+                  code={config}
                   parentCallback={this.updateConfigFn}
                 />
               </Tab>

--- a/playground/src/common/defaultConfig.ts
+++ b/playground/src/common/defaultConfig.ts
@@ -5,7 +5,7 @@ export const defaultConfig: string = `{
     "security": false,
     "messages": true,
     "schemas": true,
-    "channels": true,
+    "channels": true
   },
   "showErrors": true,
   "disableDefaultTheme": false

--- a/playground/src/common/helpers.ts
+++ b/playground/src/common/helpers.ts
@@ -36,7 +36,7 @@ function handleResponse(response: any) {
 
 export function debounce<T>(
   func: Function,
-  wait: number = 1500,
+  wait: number,
   onStart: () => void,
   onCancel: () => void,
 ): () => any {
@@ -48,6 +48,6 @@ export function debounce<T>(
       timeout = undefined;
       func(...args);
       onCancel();
-    }, wait);
+    }, wait || 1000);
   };
 }

--- a/playground/src/common/helpers.ts
+++ b/playground/src/common/helpers.ts
@@ -33,3 +33,18 @@ export const fetchSchema = async (link: string): Promise<any> => {
 function handleResponse(response: any) {
   return response.text().then((data: string) => data);
 }
+
+export function debounce(
+  func: Function,
+  context: any,
+  wait: number = 1500,
+): Function {
+  let timeout: number | undefined;
+  return function(...args: any[]) {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      func.apply(context, args);
+    }, wait);
+  };
+}

--- a/playground/src/common/helpers.ts
+++ b/playground/src/common/helpers.ts
@@ -34,17 +34,20 @@ function handleResponse(response: any) {
   return response.text().then((data: string) => data);
 }
 
-export function debounce(
+export function debounce<T>(
   func: Function,
-  context: any,
   wait: number = 1500,
-): Function {
+  onStart: () => void,
+  onCancel: () => void,
+): () => any {
   let timeout: number | undefined;
   return function(...args: any[]) {
     if (timeout) clearTimeout(timeout);
+    onStart();
     timeout = setTimeout(() => {
       timeout = undefined;
-      func.apply(context, args);
+      func(...args);
+      onCancel();
     }, wait);
   };
 }

--- a/playground/src/components/CodeEditorComponent.tsx
+++ b/playground/src/components/CodeEditorComponent.tsx
@@ -26,7 +26,7 @@ class CodeEditorComponent extends Component<Props, State> {
     code: this.props.code,
   };
 
-  componentDidUpdate(nextProps: Props, nextState: State) {
+  componentDidUpdate(nextProps: Props) {
     const { externalResource } = this.props;
     if (nextProps.externalResource !== externalResource) {
       this.setState({ code: externalResource! });

--- a/playground/src/components/styled.ts
+++ b/playground/src/components/styled.ts
@@ -84,9 +84,6 @@ export const ContentWrapper = styled.div`
 
 export const CodeEditorsWrapper = styled.div`
   width: 40%;
-  height: calc(100vh - 50px);
-  min-height: calc(100vh - 50px);
-  overflow: auto;
   background: rgb(38, 50, 56);
 `;
 
@@ -123,7 +120,7 @@ export const CodeEditorWrapper = styled.div`
 export const TabsHeader = styled.ul`
   list-style: none;
   padding: 0;
-  margin: 0 5px;
+  margin: 0 5px 15px;
   display: flex;
   justify-items: flex-start;
   flex-flow: row nowrap;
@@ -153,10 +150,14 @@ interface TabsContentProps {
 }
 
 export const TabsContent = styled.div<TabsContentProps>`
-  margin: ${props => (props.margin ? props.margin : '20px')};
+  margin: 0;
+  padding: 0 20px;
   font-size: 14px;
   color: #515559;
   line-height: 1.57;
+  overflow: auto;
+  height: calc(100vh - 122px);
+  min-height: calc(100vh - 122px);
 `;
 
 export const TabWrapper = styled.li``;

--- a/playground/src/components/styled.ts
+++ b/playground/src/components/styled.ts
@@ -133,31 +133,40 @@ export const TabsAdditionalHeaderContent = styled.li`
   padding: 19px 15px;
 `;
 
-export const RefreshIcon = styled.div`
+interface RefreshIconProps {
+  show?: boolean;
+}
+
+export const RefreshIcon = styled.div<RefreshIconProps>`
   font-family: 'SAP-Icons';
   font-weight: 700;
   color: #f77669;
-  transition: 0.2s color linear;
-  cursor: pointer;
+  transition: 0.2s all linear;
+  opacity: ${props => (props.show ? '1' : '0')};
+  animation-name: spin;
+  animation-duration: 1.5s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
 
-  &:hover {
-    color: #c3e88d;
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 `;
 
-interface TabsContentProps {
-  margin?: string;
-}
-
-export const TabsContent = styled.div<TabsContentProps>`
+export const TabsContent = styled.div`
   margin: 0;
   padding: 0 20px;
   font-size: 14px;
   color: #515559;
   line-height: 1.57;
   overflow: auto;
-  height: calc(100vh - 122px);
-  min-height: calc(100vh - 122px);
+  height: calc(100vh - 117px);
+  min-height: calc(100vh - 117px);
 `;
 
 export const TabWrapper = styled.li``;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- More info: https://github.com/asyncapi/asyncapi-react/issues/200
- Add `debounce` when user input new data in schema editor - after 750ms new view should be rendered with updated schema.
- Show refresh icon with spin animation when schema or config is updating.

> NOTE: `fix` is only added due to automatically push new playground.

New look:
![image](https://user-images.githubusercontent.com/20404945/101359137-24e56880-389c-11eb-9e10-3b54243eb5dd.png)

**Related issue(s)**
Resolves #200