### PR TITLE
fix: URL validation in playground app

### DIFF
--- a/playground/src/components/FetchSchema.tsx
+++ b/playground/src/components/FetchSchema.tsx
@@ -35,6 +35,12 @@ class FetchSchema extends Component<Props, State> {
   }
 
   private fetchSchemaFromExternalResources = async () => {
+    try {
+      // tslint:disable-next-line
+      new URL(this.state.link);
+    } catch (e) {
+      return;
+    }
     const {
       props: { parentCallback },
       state: { link },


### PR DESCRIPTION
**Addition of URL validation to the playground app**

Changes proposed in this pull request:

- asyncapi-react playground app introduces error when clicking 'Fetch schema' button, if input field remains empty or contains improperly formed URL. This pull request adds validation of the URL address entered, with URL() constructor.

**Absense of URL validation in the playground app**
