### PR TITLE
fix: show 'const' values in property description (#210)

### DIFF
--- a/library/src/containers/Schemas/SchemaProperties.tsx
+++ b/library/src/containers/Schemas/SchemaProperties.tsx
@@ -151,6 +151,16 @@ const renderPropertyDescription = (el: SchemaElement): React.ReactNode => {
           Default: <span>{el.schema.content.default}</span>
         </div>
       )}
+      {el.schema.content.hasOwnProperty('const') && (
+        <div>
+          Const:{' '}
+          <span>
+            {typeof el.schema.content.const !== 'object'
+              ? String(el.schema.content.const)
+              : JSON.stringify(el.schema.content.const)}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -339,6 +339,7 @@ export interface Schema {
   required?: string[];
   enum?: any[];
   deprecated?: boolean;
+  const?: any;
   type?: SchemaType;
   items?: Schema /*| Schema[];*/; // todo: end this
   discriminator?: string;


### PR DESCRIPTION
According to [JSON Schema specification](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.1.3)

> 6.1.3. const
> The value of this keyword MAY be of any type, including null.

So it's made `any` in 'types.ts'.
And because `const: ` can be `any` including having a value of `null`, I cannot check for existence of property `const: ` with `typeof el.schema.content.const === null` or `typeof el.schema.content.const === undefined` - 'cause these might be simply regular values of `const` (like `const: null` or `const: undefined`) saying nothing about its very existence. So I had to use `el.schema.content.hasOwnProperty('const') === true` to check that such property even exists in the object.

Every type transforms well to `String` (functions also) except `object`, so type `object` is serialized with `JSON.stringify` before rendering.

`{' '}` was added by Prettier, which adds it in React projects each time it doesn't like the length of the string, so can be removed forcefully if required.

Resolves #210 