### PR TITLE
fix: bump merge to 2.1.0

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -3120,9 +3120,9 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.0.tgz",
+      "integrity": "sha512-TcuhVDV+e6X457MQAm7xIb19rWhZuEDEho7RrwxMpQ/3GhD5sDlnP188gjQQuweXHy9igdke5oUtVOXX1X8Sxg=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/library/package.json
+++ b/library/package.json
@@ -54,7 +54,7 @@
     "constate": "^1.2.0",
     "dompurify": "^2.1.1",
     "markdown-it": "^11.0.1",
-    "merge": "^1.2.1",
+    "merge": "^2.1.0",
     "openapi-sampler": "^1.0.0-beta.15",
     "react-use": "^12.2.0"
   },


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update `merge` package from 1.2.1 to 2.1.0 to resolve WS-2020-0218 vulnerability.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
