### PR TITLE
ci: bump workflow must install deps to generate assets

### DIFF
--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -19,6 +19,9 @@ jobs:
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Install dependencies
+        run: npm install
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Assets generation
         run: npm run generate:assets
       - if: steps.packagejson.outputs.exists == 'true'  


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bump workflow must install deps to generate assets

I'm not doing another fix or as this is obvious error in the workflow that we are fixing here