### PR TITLE
feat: infer names for oneOf schemas and messages

### DIFF
--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -37,12 +37,20 @@ export const MessagesComponent: React.FunctionComponent<Props> = ({
   const content = (
     <ul className={bemClasses.element(`${className}-list`)}>
       {Object.entries(messages).map(([key, message]) => {
+        const msg = message as RawMessage;
+        let inferredName = msg['x-parser-message-name'] as string;
+        inferredName = inferredName.includes('anonymous-message')
+          ? ''
+          : inferredName;
+
         const title =
           messagesLength < 2 && inChannel
             ? ''
             : (message as RawMessage).title ||
               (message as RawMessage).name ||
+              inferredName ||
               key;
+
         return (
           <li
             key={key}

--- a/library/src/containers/Messages/Payload.tsx
+++ b/library/src/containers/Messages/Payload.tsx
@@ -96,9 +96,12 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     );
   }
 
+  const parsedId = payload['x-parser-schema-id'];
+  const title =
+    id !== undefined ? (parsedId ? `${id} ${parsedId}` : id) : PAYLOAD_TEXT;
   const header = (
     <header className={bemClasses.element(`${className}-header`)}>
-      <h4>{id !== undefined ? id : PAYLOAD_TEXT}</h4>
+      <h4>{title}</h4>
     </header>
   );
 

--- a/library/src/containers/Messages/Payload.tsx
+++ b/library/src/containers/Messages/Payload.tsx
@@ -96,9 +96,10 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     );
   }
 
-  const parsedId = payload['x-parser-schema-id'];
+  let inferredId = payload['x-parser-schema-id'] as string;
+  inferredId = inferredId.includes('anonymous-schema') ? '' : inferredId;
   const title =
-    id !== undefined ? (parsedId ? `${id} ${parsedId}` : id) : PAYLOAD_TEXT;
+    id !== undefined ? (inferredId ? `${id} ${inferredId}` : id) : PAYLOAD_TEXT;
   const header = (
     <header className={bemClasses.element(`${className}-header`)}>
       <h4>{title}</h4>

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -17,7 +17,7 @@ import {
 import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
-const defaultSchema = specs.oneOf;
+const defaultSchema = specs.streetlights;
 
 interface State {
   schema: string;

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -17,7 +17,7 @@ import {
 import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
-const defaultSchema = specs.streetlights;
+const defaultSchema = specs.oneOf;
 
 interface State {
   schema: string;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Infer names for oneOf schemas and messages. 

Example schema:

```yaml
asyncapi: 2.0.0
info:
  title: oneOf example 
  version: 1.0.0-alpha
servers:
  dev:
    url: localhost:8080
    protocol: ws
channels:
  /stream:
    description: the stream 
    subscribe:
      operationId: onStream
      summary: stream of states info
      message:
        $ref: '#/components/messages/ResponseState'
    bindings:
      ws:
        method: GET
components:
  schemas:
    ResponseState:
      description: possible states of backend
      oneOf:
        - $ref: '#/components/schemas/SomeTypeName01'
        - type: object
        - $ref: '#/components/schemas/SomeTypeName03'
    SomeTypeName01:
      type: object
    SomeTypeName02:
      type: object
    SomeTypeName03:
      type: object  
  messages:
    ResponseState:
      payload:
        $ref: '#/components/schemas/ResponseState'
      contentType: application/json
```

Generated UI:

![image](https://user-images.githubusercontent.com/20404945/110086786-18858480-7d93-11eb-8cd5-bb21ad030522.png)


**Related issue(s)**
Fixes https://github.com/asyncapi/asyncapi-react/issues/252
