### PR TITLE
refactor: switch to parser-js in most places 

### DIFF
--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -123,9 +123,8 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                 <ErrorComponent error={error} />
               )}
               {concatenatedConfig.show.info && <InfoComponent />}
-              {concatenatedConfig.show.channels && validatedSchema.channels && (
+              {concatenatedConfig.show.channels && (
                 <ChannelsComponent
-                  channels={validatedSchema.channels}
                   expand={
                     concatenatedConfig.expand &&
                     concatenatedConfig.expand.channels

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { AsyncAPIDocument } from '@asyncapi/parser';
 
 import {
   AsyncAPI,
@@ -11,7 +12,7 @@ import {
 import { ConfigInterface, defaultConfig } from '../../config';
 import { beautifier, bemClasses, stateHelpers, Parser } from '../../helpers';
 import { CSS_PREFIX } from '../../constants';
-import { useExpandedContext, useChangeHashContext } from '../../store';
+import { useSpec, useExpandedContext, useChangeHashContext } from '../../store';
 
 import { ErrorComponent } from '../Error/Error';
 import { InfoComponent } from '../Info/Info';
@@ -22,6 +23,7 @@ import { SchemasComponent } from '../Schemas/Schemas';
 
 interface AsyncAPIState {
   validatedSchema: NullableAsyncApi;
+  asyncapi: AsyncAPIDocument | null;
   error?: ErrorObject;
 }
 
@@ -37,6 +39,7 @@ const defaultAsyncApi: AsyncAPI = {
 class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
   state: AsyncAPIState = {
     validatedSchema: defaultAsyncApi,
+    asyncapi: null,
     error: undefined,
   };
   private readonly parser: Parser;
@@ -66,7 +69,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
 
   render() {
     const { config } = this.props;
-    const { validatedSchema, error } = this.state;
+    const { validatedSchema, asyncapi, error } = this.state;
     const concatenatedConfig: ConfigInterface = {
       ...defaultConfig,
       ...config,
@@ -80,7 +83,11 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
       },
     };
 
-    if (!validatedSchema || !Object.keys(validatedSchema).length) {
+    if (
+      !validatedSchema ||
+      !Object.keys(validatedSchema).length ||
+      asyncapi === null
+    ) {
       if (!error) {
         return null;
       }
@@ -105,69 +112,60 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
     );
 
     return (
-      <useExpandedContext.Provider
-        numberOfElements={numberOfElement}
-        numberOfExpandedElement={initialExpandedElements}
-      >
-        <useChangeHashContext.Provider schemaName={bemClasses.getSchemaID()}>
-          <main className={CSS_PREFIX} id={bemClasses.getSchemaID()}>
-            {concatenatedConfig.showErrors && !!error && (
-              <ErrorComponent error={error} />
-            )}
-            {concatenatedConfig.show.info && validatedSchema.info && (
-              <InfoComponent
-                info={validatedSchema.info}
-                defaultContentType={validatedSchema.defaultContentType}
-              />
-            )}
-            {concatenatedConfig.show.channels && validatedSchema.channels && (
-              <ChannelsComponent
-                channels={validatedSchema.channels}
-                expand={
-                  concatenatedConfig.expand &&
-                  concatenatedConfig.expand.channels
-                }
-              />
-            )}
-            {concatenatedConfig.show.servers && !!validatedSchema.servers && (
-              <ServersComponent
-                servers={validatedSchema.servers}
-                securitySchemes={
-                  validatedSchema.components &&
-                  validatedSchema.components.securitySchemes
-                }
-                expand={
-                  concatenatedConfig.expand && concatenatedConfig.expand.servers
-                }
-              />
-            )}
-            {validatedSchema.components && (
-              <section className={bemClasses.element(`components`)}>
-                {concatenatedConfig.show.messages &&
-                  validatedSchema.components.messages && (
+      <useSpec.Provider spec={asyncapi}>
+        <useExpandedContext.Provider
+          numberOfElements={numberOfElement}
+          numberOfExpandedElement={initialExpandedElements}
+        >
+          <useChangeHashContext.Provider schemaName={bemClasses.getSchemaID()}>
+            <main className={CSS_PREFIX} id={bemClasses.getSchemaID()}>
+              {concatenatedConfig.showErrors && !!error && (
+                <ErrorComponent error={error} />
+              )}
+              {concatenatedConfig.show.info && <InfoComponent />}
+              {concatenatedConfig.show.channels && validatedSchema.channels && (
+                <ChannelsComponent
+                  channels={validatedSchema.channels}
+                  expand={
+                    concatenatedConfig.expand &&
+                    concatenatedConfig.expand.channels
+                  }
+                />
+              )}
+              {concatenatedConfig.show.servers && (
+                <ServersComponent
+                  expand={
+                    concatenatedConfig.expand &&
+                    concatenatedConfig.expand.servers
+                  }
+                />
+              )}
+              {validatedSchema.components && (
+                <section className={bemClasses.element(`components`)}>
+                  {concatenatedConfig.show.messages && (
                     <MessagesComponent
-                      messages={validatedSchema.components.messages}
                       expand={
                         concatenatedConfig.expand &&
                         concatenatedConfig.expand.messages
                       }
                     />
                   )}
-                {concatenatedConfig.show.schemas &&
-                  validatedSchema.components.schemas && (
-                    <SchemasComponent
-                      schemas={validatedSchema.components.schemas}
-                      expand={
-                        concatenatedConfig.expand &&
-                        concatenatedConfig.expand.schemas
-                      }
-                    />
-                  )}
-              </section>
-            )}
-          </main>
-        </useChangeHashContext.Provider>
-      </useExpandedContext.Provider>
+                  {concatenatedConfig.show.schemas &&
+                    validatedSchema.components.schemas && (
+                      <SchemasComponent
+                        schemas={validatedSchema.components.schemas}
+                        expand={
+                          concatenatedConfig.expand &&
+                          concatenatedConfig.expand.schemas
+                        }
+                      />
+                    )}
+                </section>
+              )}
+            </main>
+          </useChangeHashContext.Provider>
+        </useExpandedContext.Provider>
+      </useSpec.Provider>
     );
   }
 
@@ -179,6 +177,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
       );
       this.setState({
         validatedSchema: this.beautifySchema(parsedFromUrl.data),
+        asyncapi: parsedFromUrl.asyncapi,
         error: parsedFromUrl.error,
       });
       return;
@@ -187,6 +186,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
     const parsed = await this.parser.parse(schema, parserOptions);
     this.setState({
       validatedSchema: this.beautifySchema(parsed.data),
+      asyncapi: parsed.asyncapi,
       error: parsed.error,
     });
   }

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -150,16 +150,14 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                       }
                     />
                   )}
-                  {concatenatedConfig.show.schemas &&
-                    validatedSchema.components.schemas && (
-                      <SchemasComponent
-                        schemas={validatedSchema.components.schemas}
-                        expand={
-                          concatenatedConfig.expand &&
-                          concatenatedConfig.expand.schemas
-                        }
-                      />
-                    )}
+                  {concatenatedConfig.show.schemas && (
+                    <SchemasComponent
+                      expand={
+                        concatenatedConfig.expand &&
+                        concatenatedConfig.expand.schemas
+                      }
+                    />
+                  )}
                 </section>
               )}
             </main>

--- a/library/src/containers/Channels/Channels.tsx
+++ b/library/src/containers/Channels/Channels.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { ChannelComponent } from './Channel';
 
 import { ExpandNestedConfig } from '../../config';
-import { bemClasses } from '../../helpers';
-import { Channels } from '../../types';
 import { Toggle } from '../../components';
 import { CHANNELS_TEXT, CONTAINER_LABELS } from '../../constants';
+import { bemClasses } from '../../helpers';
+import { useSpec } from '../../store';
+import { Channels } from '../../types';
 
 interface Props {
   channels: Channels;
@@ -14,19 +15,26 @@ interface Props {
 }
 
 export const ChannelsComponent: React.FunctionComponent<Props> = ({
-  channels,
   expand,
 }) => {
-  const className = CONTAINER_LABELS.CHANNELS;
+  const channels = useSpec().channels();
 
+  if (!Object.keys(channels).length) {
+    return null;
+  }
+
+  const className = CONTAINER_LABELS.CHANNELS;
   const header = <h2>{CHANNELS_TEXT}</h2>;
 
   const content = (
     <ul className={bemClasses.element(`${className}-list`)}>
-      {Object.entries(channels).map(([name, channel]) => (
-        <li key={name} className={bemClasses.element(`${className}-list-item`)}>
+      {Object.entries(channels).map(([channelName, channel]) => (
+        <li
+          key={channelName}
+          className={bemClasses.element(`${className}-list-item`)}
+        >
           <ChannelComponent
-            name={name}
+            channelName={channelName}
             channel={channel}
             toggleExpand={expand && expand.elements}
           />

--- a/library/src/containers/Channels/Channels.tsx
+++ b/library/src/containers/Channels/Channels.tsx
@@ -7,10 +7,8 @@ import { Toggle } from '../../components';
 import { CHANNELS_TEXT, CONTAINER_LABELS } from '../../constants';
 import { bemClasses } from '../../helpers';
 import { useSpec } from '../../store';
-import { Channels } from '../../types';
 
 interface Props {
-  channels: Channels;
   expand?: ExpandNestedConfig;
 }
 

--- a/library/src/containers/Channels/Parameter.tsx
+++ b/library/src/containers/Channels/Parameter.tsx
@@ -1,36 +1,40 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
+import { ChannelParameter } from '@asyncapi/parser';
 
 import { SchemaComponent } from '../Schemas/Schema';
 
 import { bemClasses } from '../../helpers';
-import { Parameter as ParamType } from '../../types';
 import { LOCATION_TEXT } from '../../constants';
 
 interface Props {
-  name: string;
-  param: ParamType;
+  parameterName: string;
+  parameter: ChannelParameter;
 }
 
-export const Parameter: FunctionComponent<Props> = ({
-  param: { description, location, schema },
-  name = '',
-}) => (
-  <div className={bemClasses.element(`channel-parameter`)}>
-    <header className={bemClasses.element(`channel-parameter-header`)}>
-      {location && (
-        <h4>
-          {LOCATION_TEXT}: {location}
-        </h4>
-      )}
-    </header>
-    <div className={bemClasses.element(`channel-parameter-schema`)}>
-      <SchemaComponent
-        name={name}
-        schema={schema}
-        hideTitle={true}
-        description={description}
-        required={true} // parameters are always required
-      />
+export const Parameter: React.FunctionComponent<Props> = ({
+  parameterName = '',
+  parameter,
+}) => {
+  const location = parameter.location();
+
+  return (
+    <div className={bemClasses.element(`channel-parameter`)}>
+      <header className={bemClasses.element(`channel-parameter-header`)}>
+        {location && (
+          <h4>
+            {LOCATION_TEXT}: {location}
+          </h4>
+        )}
+      </header>
+      <div className={bemClasses.element(`channel-parameter-schema`)}>
+        <SchemaComponent
+          name={parameterName}
+          schema={parameter.schema().json() as any}
+          hideTitle={true}
+          description={parameter.description()}
+          required={true} // parameters are always required
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/library/src/containers/Channels/Parameters.tsx
+++ b/library/src/containers/Channels/Parameters.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
+import { ChannelParameter } from '@asyncapi/parser';
 
 import { Parameter } from './Parameter';
 
 import { bemClasses } from '../../helpers';
-import { Parameters as ParametersType } from '../../types';
 import { PARAMETERS_TEXT } from '../../constants';
 
 interface Props {
-  parameters?: ParametersType;
+  parameters?: Record<string, ChannelParameter>;
   identifier: string;
   dataIdentifier: string;
 }
 
 export const Parameters: React.FunctionComponent<Props> = ({
-  parameters,
+  parameters = {},
   identifier,
   dataIdentifier,
 }) => {
-  if (!parameters) {
+  if (!Object.keys(parameters).length) {
     return null;
   }
 
@@ -31,12 +31,12 @@ export const Parameters: React.FunctionComponent<Props> = ({
         <h4>{PARAMETERS_TEXT}</h4>
       </header>
       <ul className={bemClasses.element(`channel-parameters-list`)}>
-        {Object.entries(parameters).map(([name, param]) => (
+        {Object.entries(parameters).map(([parameterName, parameter]) => (
           <li
-            key={name}
+            key={parameterName}
             className={bemClasses.element(`channel-parameters-list-item`)}
           >
-            <Parameter param={param} name={name} />
+            <Parameter parameterName={parameterName} parameter={parameter} />
           </li>
         ))}
       </ul>

--- a/library/src/containers/Info/Info.tsx
+++ b/library/src/containers/Info/Info.tsx
@@ -7,17 +7,17 @@ import { DefaultContentTypeComponent } from './DefaultContentType';
 
 import { Markdown, CollapseButton } from '../../components';
 import { bemClasses } from '../../helpers';
-import { Info, DefaultContentType } from '../../types';
+import { useSpec } from '../../store';
 
-interface Props {
-  info: Info;
-  defaultContentType?: DefaultContentType;
-}
+export const InfoComponent: React.FunctionComponent = () => {
+  const asyncapi = useSpec();
+  const info = asyncapi.info();
 
-export const InfoComponent: React.FunctionComponent<Props> = ({
-  info: { title, version, description, termsOfService, contact, license },
-  defaultContentType,
-}) => {
+  const termsOfService = info.termsOfService();
+  const contact = info.contact();
+  const license = info.license();
+  const defaultContentType = asyncapi.defaultContentType();
+
   const className = `info`;
   const showInfoList =
     defaultContentType || termsOfService || license || contact;
@@ -31,19 +31,15 @@ export const InfoComponent: React.FunctionComponent<Props> = ({
         <div className={bemClasses.element(`${className}-header-main`)}>
           <h1>
             <span className={bemClasses.element(`${className}-header-title`)}>
-              {title}
+              {info.title()}
             </span>
-            {version && (
-              <span
-                className={bemClasses.element(`${className}-header-version`)}
-              >
-                {version}
-              </span>
-            )}
+            <span className={bemClasses.element(`${className}-header-version`)}>
+              {info.version()}
+            </span>
           </h1>
           <CollapseButton />
         </div>
-        {!showInfoList ? null : (
+        {showInfoList && (
           <ul className={bemClasses.element(`${className}-list`)}>
             {defaultContentType && (
               <li
@@ -63,18 +59,18 @@ export const InfoComponent: React.FunctionComponent<Props> = ({
             )}
             {license && (
               <li className={bemClasses.element(`${className}-license`)}>
-                <LicenseComponent {...license} />
+                <LicenseComponent name={license.name()} url={license.url()} />
               </li>
             )}
-            {contact && (contact.url || contact.email) ? (
-              <ContactComponent {...contact} />
-            ) : null}
+            {contact && (
+              <ContactComponent url={contact.url()} email={contact.email()} />
+            )}
           </ul>
         )}
       </header>
-      {description && (
+      {info.hasDescription() && (
         <div className={bemClasses.element(`${className}-description`)}>
-          <Markdown>{description}</Markdown>
+          <Markdown>{info.description()}</Markdown>
         </div>
       )}
     </section>

--- a/library/src/containers/Info/License.tsx
+++ b/library/src/containers/Info/License.tsx
@@ -9,6 +9,5 @@ export const LicenseComponent: React.FunctionComponent<License> = ({
   url,
 }) => {
   const nameWrapper = <span>{name}</span>;
-
   return <div>{url ? <Href href={url}>{nameWrapper}</Href> : nameWrapper}</div>;
 };

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -48,15 +48,10 @@ export const MessagesComponent: React.FunctionComponent<Props> = ({
     <ul className={bemClasses.element(`${className}-list`)}>
       {Object.entries(messages).map(([key, msg]) => {
         // check it without `.uid()` function
-        let inferredName = (msg.ext['x-parser-message-name'] as string) || '';
-        inferredName = inferredName.includes('anonymous-message')
-          ? ''
-          : inferredName;
+        let name = msg.uid();
+        name = name.includes('anonymous-message') ? '' : name;
 
-        const title =
-          messagesLength < 2 && inChannel
-            ? ''
-            : msg.uid() || inferredName || `${key}`;
+        const title = messagesLength < 2 && inChannel ? '' : name || `${key}`;
 
         return (
           <li

--- a/library/src/containers/Messages/Payload.tsx
+++ b/library/src/containers/Messages/Payload.tsx
@@ -97,8 +97,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     );
   }
 
-  // check it without `.uid()` function
-  let inferredId = (payload.ext['x-parser-schema-id'] as string) || '';
+  let inferredId = (payload.ext('x-parser-schema-id') as string) || '';
   inferredId = inferredId.includes('anonymous-schema') ? '' : inferredId;
   const title =
     id !== undefined ? (inferredId ? `${id} ${inferredId}` : id) : PAYLOAD_TEXT;

--- a/library/src/containers/Messages/Payload.tsx
+++ b/library/src/containers/Messages/Payload.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { Schema } from '@asyncapi/parser';
 
 import { SchemaComponent } from '../Schemas/Schema';
 
 import { bemClasses } from '../../helpers';
-import { RawMessage, isOneOfPayload, isAnyOfPayload } from '../../types';
 import { Toggle } from '../../components';
 import {
   ONE_OF_PAYLOADS_TEXT,
@@ -13,7 +13,8 @@ import {
   PAYLOAD_EXAMPLE_TEXT,
 } from '../../constants';
 
-interface Props extends Required<Pick<RawMessage, 'payload'>> {
+interface Props {
+  payload: Schema;
   oneOf?: boolean;
   anyOf?: boolean;
   identifier?: string;
@@ -34,7 +35,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
   const className = `message-payload`;
   const payloadsID = identifier ? `${identifier}s` : undefined;
 
-  if (isOneOfPayload(payload)) {
+  if (payload.oneOf()) {
     return (
       <div
         className={bemClasses.element(`${className}-oneOf`)}
@@ -45,7 +46,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
           <h4>{ONE_OF_PAYLOADS_TEXT}</h4>
         </header>
         <ul className={bemClasses.element(`${className}-oneOf-list`)}>
-          {payload.oneOf.map((elem, index: number) => (
+          {payload.oneOf().map((elem, index: number) => (
             <li
               key={index}
               className={bemClasses.element(`${className}-oneOf-list-item`)}
@@ -65,7 +66,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     );
   }
 
-  if (isAnyOfPayload(payload)) {
+  if (payload.anyOf()) {
     return (
       <div
         className={bemClasses.element(`${className}-anyOf`)}
@@ -76,7 +77,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
           <h4>{ANY_OF_PAYLOADS_TEXT}</h4>
         </header>
         <ul className={bemClasses.element(`${className}-anyOf-list`)}>
-          {payload.anyOf.map((elem, index: number) => (
+          {payload.anyOf().map((elem, index: number) => (
             <li
               key={index}
               className={bemClasses.element(`${className}-anyOf-list-item`)}
@@ -96,7 +97,8 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     );
   }
 
-  let inferredId = (payload['x-parser-schema-id'] as string) || '';
+  // check it without `.uid()` function
+  let inferredId = (payload.ext['x-parser-schema-id'] as string) || '';
   inferredId = inferredId.includes('anonymous-schema') ? '' : inferredId;
   const title =
     id !== undefined ? (inferredId ? `${id} ${inferredId}` : id) : PAYLOAD_TEXT;
@@ -110,7 +112,7 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
     <div className={bemClasses.element(`${className}-schema`)}>
       <SchemaComponent
         name={MESSAGE_PAYLOAD_TEXT}
-        schema={payload}
+        schema={payload.json()}
         exampleTitle={PAYLOAD_EXAMPLE_TEXT}
         hideTitle={true}
         examples={examples}
@@ -120,17 +122,15 @@ export const PayloadComponent: React.FunctionComponent<Props> = ({
 
   let payloadID;
   if (identifier) {
-    payloadID =
-      payload.title && payload.title.length
-        ? `${identifier}-${payload.title}`
-        : `${identifier}${id !== undefined ? `-${id}` : ''}`;
+    payloadID = payload.title()
+      ? `${identifier}-${payload.title()}`
+      : `${identifier}${id !== undefined ? `-${id}` : ''}`;
   }
   let payloadDataID;
   if (dataIdentifier) {
-    payloadDataID =
-      payload.title && payload.title.length
-        ? `${dataIdentifier}-${payload.title}`
-        : `${dataIdentifier}${id !== undefined ? `-${id}` : ''}`;
+    payloadDataID = payload.title()
+      ? `${dataIdentifier}-${payload.title()}`
+      : `${dataIdentifier}${id !== undefined ? `-${id}` : ''}`;
   }
 
   if (oneOf || anyOf) {

--- a/library/src/containers/Schemas/Schemas.tsx
+++ b/library/src/containers/Schemas/Schemas.tsx
@@ -6,31 +6,30 @@ import { ExpandNestedConfig } from '../../config';
 import { bemClasses } from '../../helpers';
 import { Toggle } from '../../components';
 import { SCHEMAS_TEXT, CONTAINER_LABELS } from '../../constants';
-import { Schema } from '../../types';
+import { useSpec } from '../../store';
 
 interface Props {
-  schemas?: Record<string, Schema>;
   expand?: ExpandNestedConfig;
 }
 
 export const SchemasComponent: React.FunctionComponent<Props> = ({
-  schemas,
   expand,
 }) => {
-  if (!schemas) {
+  const schemas = useSpec().allSchemas();
+  if (!schemas.size) {
     return null;
   }
-  const className = CONTAINER_LABELS.SCHEMAS;
 
+  const className = CONTAINER_LABELS.SCHEMAS;
   const header = <h2>{SCHEMAS_TEXT}</h2>;
 
   const content = (
     <ul className={bemClasses.element(`${className}-list`)}>
-      {Object.entries(schemas).map(([key, schema]) => (
+      {Array.from(schemas).map(([key, schema]) => (
         <li key={key} className={bemClasses.element(`${className}-list-item`)}>
           <SchemaComponent
             name={key}
-            schema={schema}
+            schema={schema.json()}
             toggle={true}
             toggleExpand={expand && expand.elements}
           />

--- a/library/src/containers/Servers/Flow.tsx
+++ b/library/src/containers/Servers/Flow.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { OAuthFlow } from '@asyncapi/parser';
 
 import { ServerSecurityFlowScopes } from './Scopes';
 
 import { bemClasses } from '../../helpers';
 import { Href } from '../../components';
-import { OAuthFlow, OAuthFlowsType } from '../../types';
+import { OAuthFlowsType } from '../../types';
 import { FLOWS_TEXTS } from '../../constants';
 
 interface Props {
@@ -15,36 +16,44 @@ interface Props {
 export const ServerSecurityFlow: React.FunctionComponent<Props> = ({
   name,
   flow,
-}) => (
-  <div className={bemClasses.element(`server-security-flow`)}>
-    <ul className={bemClasses.element(`server-security-flow-list`)}>
-      <li className={bemClasses.element(`server-security-flow-list-item`)}>
-        <strong>{FLOWS_TEXTS.FLOW}</strong>:<span>{OAuthFlowsType[name]}</span>
-      </li>
-      {flow.authorizationUrl && (
+}) => {
+  const authorizationUrl = flow.authorizationUrl();
+  const tokenUrl = flow.tokenUrl();
+  const refreshUrl = flow.refreshUrl();
+  const scopes = flow.scopes();
+
+  return (
+    <div className={bemClasses.element(`server-security-flow`)}>
+      <ul className={bemClasses.element(`server-security-flow-list`)}>
         <li className={bemClasses.element(`server-security-flow-list-item`)}>
-          <strong>{FLOWS_TEXTS.AUTHORIZATION_URL}:</strong>
-          <Href href={flow.authorizationUrl}>{flow.authorizationUrl}</Href>
+          <strong>{FLOWS_TEXTS.FLOW}</strong>:
+          <span>{OAuthFlowsType[name]}</span>
         </li>
-      )}
-      {flow.tokenUrl && (
-        <li className={bemClasses.element(`server-security-flow-list-item`)}>
-          <strong>{FLOWS_TEXTS.TOKEN_URL}</strong>:
-          <Href href={flow.tokenUrl}>{flow.tokenUrl}</Href>
-        </li>
-      )}
-      {flow.refreshUrl && (
-        <li className={bemClasses.element(`server-security-flow-list-item`)}>
-          <strong>{FLOWS_TEXTS.REFRESH_URL}</strong>:
-          <Href href={flow.refreshUrl}>{flow.refreshUrl}</Href>
-        </li>
-      )}
-      {flow.scopes && (
-        <li className={bemClasses.element(`server-security-flow-list-item`)}>
-          <strong>{FLOWS_TEXTS.SCOPES}</strong>:
-          <ServerSecurityFlowScopes scopes={flow.scopes} />
-        </li>
-      )}
-    </ul>
-  </div>
-);
+        {authorizationUrl && (
+          <li className={bemClasses.element(`server-security-flow-list-item`)}>
+            <strong>{FLOWS_TEXTS.AUTHORIZATION_URL}:</strong>
+            <Href href={authorizationUrl}>{authorizationUrl}</Href>
+          </li>
+        )}
+        {tokenUrl && (
+          <li className={bemClasses.element(`server-security-flow-list-item`)}>
+            <strong>{FLOWS_TEXTS.TOKEN_URL}</strong>:
+            <Href href={tokenUrl}>{tokenUrl}</Href>
+          </li>
+        )}
+        {refreshUrl && (
+          <li className={bemClasses.element(`server-security-flow-list-item`)}>
+            <strong>{FLOWS_TEXTS.REFRESH_URL}</strong>:
+            <Href href={refreshUrl}>{refreshUrl}</Href>
+          </li>
+        )}
+        {scopes && (
+          <li className={bemClasses.element(`server-security-flow-list-item`)}>
+            <strong>{FLOWS_TEXTS.SCOPES}</strong>:
+            <ServerSecurityFlowScopes scopes={scopes} />
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};

--- a/library/src/containers/Servers/Flows.tsx
+++ b/library/src/containers/Servers/Flows.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import { OAuthFlow } from '@asyncapi/parser';
 
 import { ServerSecurityFlow } from './Flow';
 
 import { TableRow } from '../../components';
 import { bemClasses } from '../../helpers';
-import { OAuthFlows, OAuthFlow } from '../../types';
 
 interface Props {
-  flows: OAuthFlows;
+  flows: {
+    [key: string]: OAuthFlow;
+  };
 }
 
 export const ServerSecurityFlows: React.FunctionComponent<Props> = ({
@@ -17,23 +19,22 @@ export const ServerSecurityFlows: React.FunctionComponent<Props> = ({
     return null;
   }
 
-  const sortedFlows: OAuthFlows = Object.keys(flows)
-    .sort()
-    .reduce((accumulator, currentValue) => {
-      accumulator[currentValue] = flows[currentValue];
-      return accumulator;
-    }, {});
+  // TODO: check if this should be removed
+  // const sortedFlows: { [key: string]: OAuthFlow } = Object.keys(flows)
+  //   .sort()
+  //   .reduce((accumulator, currentValue) => {
+  //     accumulator[currentValue] = flows[currentValue];
+  //     return accumulator;
+  //   }, {});
 
-  const nodes = Object.entries(sortedFlows).map(
-    ([flowName, flow]: [string, OAuthFlow]) => (
-      <li
-        key={flowName}
-        className={bemClasses.element(`server-security-flows-list-item`)}
-      >
-        <ServerSecurityFlow name={flowName} flow={flow} />
-      </li>
-    ),
-  );
+  const nodes = Object.entries(flows).map(([flowName, flow]) => (
+    <li
+      key={flowName}
+      className={bemClasses.element(`server-security-flows-list-item`)}
+    >
+      <ServerSecurityFlow name={flowName} flow={flow} />
+    </li>
+  ));
 
   const nestedTableCellClassName = bemClasses.modifier(`nested`, `table-cell`);
   const flowsTableCellClassName = bemClasses.element(

--- a/library/src/containers/Servers/Security.tsx
+++ b/library/src/containers/Servers/Security.tsx
@@ -1,31 +1,28 @@
 import React from 'react';
+import { SecurityScheme, ServerSecurityRequirement } from '@asyncapi/parser';
 
 import { ServerSecurityItemComponent } from './SecurityItem';
 
 import { Table } from '../../components';
 import { bemClasses } from '../../helpers';
-import {
-  Components,
-  SecurityRequirement,
-  ExcludeNullable,
-  SecurityScheme,
-} from '../../types';
+import { useSpec } from '../../store';
 import { SECURITY_TEXT, SERVER_SECURITY_COLUMN_NAMES } from '../../constants';
 
 interface Props {
-  requirements: SecurityRequirement[];
-  schemes: ExcludeNullable<Components['securitySchemes']>;
-  openAccordion?: boolean;
+  requirements: ServerSecurityRequirement[];
   identifier: string;
   dataIdentifier: string;
 }
 
 export const ServerSecurityComponent: React.FunctionComponent<Props> = ({
   requirements,
-  schemes,
   identifier: id,
   dataIdentifier: dataId,
 }) => {
+  const asyncapi = useSpec();
+  const securitySchemes =
+    asyncapi.hasComponents() && asyncapi.components().securitySchemes();
+
   const identifier = bemClasses.identifier([
     { id, toKebabCase: false },
     'security',
@@ -38,19 +35,19 @@ export const ServerSecurityComponent: React.FunctionComponent<Props> = ({
 
   const rows: React.ReactNodeArray = requirements
     .map(requirement => {
-      const def: SecurityScheme | undefined =
-        schemes[Object.keys(requirement)[0]];
+      const def: SecurityScheme =
+        securitySchemes[Object.keys(requirement.json())[0]];
 
       if (!def) {
         return null;
       }
       return (
-        <ServerSecurityItemComponent securityScheme={def} key={def.type} />
+        <ServerSecurityItemComponent securityScheme={def} key={def.type()} />
       );
     })
     .filter(Boolean);
 
-  if (!rows || !rows.length) {
+  if (!rows.length) {
     return null;
   }
 

--- a/library/src/containers/Servers/SecurityItem.tsx
+++ b/library/src/containers/Servers/SecurityItem.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
+import { SecurityScheme } from '@asyncapi/parser';
 
 import { ServerSecurityFlows } from './Flows';
 
-import { SecurityScheme } from '../../types';
 import { Markdown, TableAccessor, TableRow } from '../../components';
 import { bemClasses } from '../../helpers';
 
 const securitySchemeAccessors: Array<TableAccessor<SecurityScheme>> = [
-  el => <span>{el.type}</span>,
-  el => <span>{el.bearerFormat}</span>,
-  el => <span>{el.in}</span>,
-  el => <span>{el.scheme}</span>,
-  el => <span>{el.name}</span>,
-  el => el.description && <Markdown>{el.description}</Markdown>,
+  el => <span>{el.type()}</span>,
+  el => <span>{el.bearerFormat()}</span>,
+  el => <span>{el.in()}</span>,
+  el => <span>{el.scheme()}</span>,
+  el => <span>{el.name()}</span>,
+  el => el.hasDescription() && <Markdown>{el.description()}</Markdown>,
 ];
 
 interface Props {
@@ -26,10 +26,10 @@ export const ServerSecurityItemComponent: React.FunctionComponent<Props> = ({
     <TableRow
       element={securityScheme}
       accessors={securitySchemeAccessors}
-      className={bemClasses.element(`server-security-${securityScheme.type}`)}
+      className={bemClasses.element(`server-security-${securityScheme.type()}`)}
     />
     {securityScheme.flows && (
-      <ServerSecurityFlows flows={securityScheme.flows} />
+      <ServerSecurityFlows flows={securityScheme.flows()} />
     )}
   </>
 );

--- a/library/src/containers/Servers/Servers.tsx
+++ b/library/src/containers/Servers/Servers.tsx
@@ -4,40 +4,36 @@ import { ServerComponent } from './Server';
 
 import { ExpandNestedConfig } from '../../config';
 import { bemClasses } from '../../helpers';
-import { Servers, SecurityScheme } from '../../types';
+import { useSpec } from '../../store';
 import { Toggle } from '../../components';
 import { SERVERS, CONTAINER_LABELS } from '../../constants';
 
 interface Props {
-  servers?: Servers;
-  securitySchemes?: Record<string, SecurityScheme>;
   expand?: ExpandNestedConfig;
 }
 
 export const ServersComponent: React.FunctionComponent<Props> = ({
-  servers,
-  securitySchemes,
   expand,
 }) => {
-  if (!servers) {
+  const servers = useSpec().servers();
+
+  if (!Object.keys(servers).length) {
     return null;
   }
+
   const className = CONTAINER_LABELS.SERVERS;
-
   const header = <h2>{SERVERS}</h2>;
-
   const content = (
     <ul className={bemClasses.element(`${className}-list`)}>
-      {Object.entries(servers).map(([stage, server]) => (
+      {Object.entries(servers).map(([serverName, server]) => (
         <li
-          key={stage}
+          key={serverName}
           className={bemClasses.element(`${className}-list-item`)}
         >
           <ServerComponent
-            key={`${server.url}${stage}`}
+            key={serverName}
+            serverName={serverName}
             server={server}
-            stage={stage}
-            securitySchemes={securitySchemes}
             toggleExpand={expand && expand.elements}
           />
         </li>

--- a/library/src/containers/Servers/Variables.tsx
+++ b/library/src/containers/Servers/Variables.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { ServerVariable } from '@asyncapi/parser';
 
 import { bemClasses } from '../../helpers';
-import { ServerVariable, TypeWithKey } from '../../types';
+import { TypeWithKey } from '../../types';
 import {
   Markdown,
   Table,
@@ -20,15 +21,15 @@ type ServerVariableWithKey = TypeWithKey<string, ServerVariable>;
 const serverVariablesAccessors: Array<TableAccessor<ServerVariableWithKey>> = [
   el => <span>{el.key}</span>,
   el =>
-    el.content.default ? (
-      <span>{el.content.default}</span>
+    el.content.hasDefaultValue() ? (
+      <span>{el.content.defaultValue()}</span>
     ) : (
       <em>{NONE_TEXT}</em>
     ),
   el =>
-    el.content.enum ? (
+    el.content.hasAllowedValues() ? (
       <ul className={bemClasses.element(`server-variables-enum-list`)}>
-        {el.content.enum.map(value => (
+        {el.content.allowedValues().map(value => (
           <li
             className={bemClasses.element(`server-variables-enum-list-item`)}
             key={value}
@@ -40,7 +41,10 @@ const serverVariablesAccessors: Array<TableAccessor<ServerVariableWithKey>> = [
     ) : (
       <em>{ANY_TEXT}</em>
     ),
-  el => el.content.description && <Markdown>{el.content.description}</Markdown>,
+  el =>
+    el.content.hasDescription() && (
+      <Markdown>{el.content.description()}</Markdown>
+    ),
 ];
 
 interface Props {
@@ -57,6 +61,7 @@ export const ServerVariablesComponent: React.FunctionComponent<Props> = ({
   if (!variables.length) {
     return null;
   }
+
   const className = `server-variables`;
   const rows: TableRowProps[] = variables.map(variable => ({
     key: variable.key,

--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -58,26 +58,30 @@ export class Parser {
     if (err.type === VALIDATION_ERRORS_TYPE) {
       return {
         data: err.parsedJSON || null,
+        asyncapi: null,
         error: err,
       };
     }
 
-    return { data: null, error: err };
+    return { data: null, asyncapi: null, error: err };
   };
 
   private extractDocument = (data: any): ParserReturn => {
     if (data.json instanceof Function) {
       return {
         data: data.json(),
+        asyncapi: data,
       };
     }
     if (typeof data._json === 'object') {
       return {
         data: data._json,
+        asyncapi: data,
       };
     }
     return {
       data,
+      asyncapi: data,
     };
   };
 }

--- a/library/src/store/index.ts
+++ b/library/src/store/index.ts
@@ -1,2 +1,3 @@
 export * from './useExpandedState';
 export * from './useChangeHash';
+export * from './useSpec';

--- a/library/src/store/useSpec.ts
+++ b/library/src/store/useSpec.ts
@@ -1,0 +1,12 @@
+import { AsyncAPIDocument } from '@asyncapi/parser';
+import createUseContext from 'constate';
+
+interface Props {
+  spec: AsyncAPIDocument;
+}
+
+function useSpecContext({ spec }: Props) {
+  return spec;
+}
+
+export const useSpec = createUseContext(useSpecContext);

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -1,3 +1,4 @@
+import { AsyncAPIDocument } from '@asyncapi/parser';
 import { ConfigInterface } from './config';
 
 // Helpers
@@ -397,6 +398,7 @@ export interface FetchingSchemaInterface {
 
 export interface ParserReturn {
   data: NullableAsyncApi;
+  asyncapi: AsyncAPIDocument | null;
   error?: ErrorObject;
 }
 

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -17,7 +17,7 @@ import {
 import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
-const defaultSchema = specs.oneOf;
+const defaultSchema = specs.streetlights;
 
 interface State {
   schema: string;

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -17,7 +17,7 @@ import {
 import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
-const defaultSchema = specs.streetlights;
+const defaultSchema = specs.oneOf;
 
 interface State {
   schema: string;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

> if someone think that the PR is too big, I will try to divide the PR into two smaller ones.

Changes proposed in this pull request:
- Switch to `parser-js` in `Info`, `Servers` (also in single `Server`), `Channels` (also in single `Channel`), `Messages` (also in single `Message`), `Schemas` components,
- left single `Schema` component, because it is the most complicated component in package and it should be rewritten with https://github.com/asyncapi/shape-up-process/issues/87 task - also by this I left some code related to "beautify" our schema - if `Schema` component will be rewritten, we will remove about leftover 10-15% of code.
- I wanna treat PR as chore, because I wanna merge to `unify-component` branch :)

**Related issue(s)**
Part of https://github.com/asyncapi/shape-up-process/issues/85
