### PR TITLE
refactor: unify Messages and Operations components

### DIFF
--- a/library/src/components/Markdown.tsx
+++ b/library/src/components/Markdown.tsx
@@ -7,6 +7,9 @@ import { bemClasses } from '../helpers';
 const markdownIt = new MarkdownIt();
 
 export const Markdown: React.FunctionComponent = ({ children }) => {
+  if (!children) {
+    return null;
+  }
   if (typeof children !== 'string') {
     return <>{children}</>;
   }

--- a/library/src/components/Tag.tsx
+++ b/library/src/components/Tag.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Tag as TagType } from '@asyncapi/parser';
+
+interface Props {
+  tag: TagType;
+}
+
+export const Tag: React.FunctionComponent<Props> = ({ tag }) => {
+  const externalDocs = tag.externalDocs();
+
+  if (externalDocs) {
+    return (
+      <a
+        href={externalDocs.url()}
+        target="_blank"
+        className="border text-blue-400 font-normal text-sm rounded lowercase mr-2 px-2 py-1"
+        title={tag.description() || ''}
+      >
+        {tag.name()}
+      </a>
+    );
+  }
+  return (
+    <span
+      className="border font-normal text-sm no-underline text-blue-400 rounded lowercase mr-2 px-2 py-1"
+      title={tag.description() || ''}
+    >
+      {tag.name()}
+    </span>
+  );
+};

--- a/library/src/components/Tag.tsx
+++ b/library/src/components/Tag.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import { bemClasses } from '../helpers';
-
-export const Tag: React.FunctionComponent = ({ children }) => (
-  <span className={bemClasses.element(`tag`)}>{children}</span>
-);

--- a/library/src/components/Tags.tsx
+++ b/library/src/components/Tags.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Tag } from '@asyncapi/parser';
+import { Tag as TagType } from '@asyncapi/parser';
 
 interface Props {
-  tags?: Tag[];
+  tags?: TagType[];
 }
 
 export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
@@ -13,17 +13,13 @@ export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
   return (
     <div className="mt-4">
       {tags.map(tag => (
-        <TagComponent tag={tag} />
+        <Tag tag={tag} />
       ))}
     </div>
   );
 };
 
-interface TagProps {
-  tag: Tag;
-}
-
-const TagComponent: React.FunctionComponent<TagProps> = ({ tag }) => {
+const Tag: React.FunctionComponent<{ tag: TagType }> = ({ tag }) => {
   const externalDocs = tag.externalDocs();
 
   if (externalDocs) {

--- a/library/src/components/Tags.tsx
+++ b/library/src/components/Tags.tsx
@@ -13,7 +13,7 @@ export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
   return (
     <div className="mt-4">
       {tags.map(tag => (
-        <Tag tag={tag} />
+        <Tag tag={tag} key={tag.name()} />
       ))}
     </div>
   );

--- a/library/src/components/Tags.tsx
+++ b/library/src/components/Tags.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Tag as TagType } from '@asyncapi/parser';
 
+import { Tag } from './Tag';
+
 interface Props {
   tags?: TagType[];
 }
@@ -16,30 +18,5 @@ export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
         <Tag tag={tag} key={tag.name()} />
       ))}
     </div>
-  );
-};
-
-const Tag: React.FunctionComponent<{ tag: TagType }> = ({ tag }) => {
-  const externalDocs = tag.externalDocs();
-
-  if (externalDocs) {
-    return (
-      <a
-        href={externalDocs.url()}
-        target="_blank"
-        className="border text-blue-400 font-normal text-sm rounded lowercase mr-2 px-2 py-1"
-        title={tag.description() || ''}
-      >
-        {tag.name()}
-      </a>
-    );
-  }
-  return (
-    <span
-      className="border font-normal text-sm no-underline text-blue-400 rounded lowercase mr-2 px-2 py-1"
-      title={tag.description() || ''}
-    >
-      {tag.name()}
-    </span>
   );
 };

--- a/library/src/components/Tags.tsx
+++ b/library/src/components/Tags.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Tag } from '@asyncapi/parser';
+
+interface Props {
+  tags?: Tag[];
+}
+
+export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
+  if (!tags || !tags.length) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4">
+      {tags.map(tag => (
+        <TagComponent tag={tag} />
+      ))}
+    </div>
+  );
+};
+
+interface TagProps {
+  tag: Tag;
+}
+
+const TagComponent: React.FunctionComponent<TagProps> = ({ tag }) => {
+  const externalDocs = tag.externalDocs();
+
+  if (externalDocs) {
+    return (
+      <a
+        href={externalDocs.url()}
+        target="_blank"
+        className="border text-blue-400 font-normal text-sm rounded lowercase mr-2 px-2 py-1"
+        title={tag.description() || ''}
+      >
+        {tag.name()}
+      </a>
+    );
+  }
+  return (
+    <span
+      className="border font-normal text-sm no-underline text-blue-400 rounded lowercase mr-2 px-2 py-1"
+      title={tag.description() || ''}
+    >
+      {tag.name()}
+    </span>
+  );
+};

--- a/library/src/components/index.ts
+++ b/library/src/components/index.ts
@@ -6,7 +6,7 @@ export * from './TableHeader';
 export * from './TableRow';
 export * from './Href';
 export * from './Markdown';
-export * from './Tag';
+export * from './Tags';
 export * from './Tree';
 export * from './Toggle';
 export * from './CollapseButton';

--- a/library/src/components/index.ts
+++ b/library/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './TableHeader';
 export * from './TableRow';
 export * from './Href';
 export * from './Markdown';
+export * from './Tag';
 export * from './Tags';
 export * from './Tree';
 export * from './Toggle';

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -17,8 +17,8 @@ import { useSpec, useExpandedContext, useChangeHashContext } from '../../store';
 import { ErrorComponent } from '../Error/Error';
 import { InfoComponent } from '../Info/NewInfo';
 import { ServersComponent } from '../Servers/Servers';
-import { OperationsComponent } from '../Channels/NewOperations';
-import { MessagesComponent } from '../Messages/NewMessages';
+import { Operations } from '../Channels/NewOperations';
+import { Messages } from '../Messages/NewMessages';
 import { SchemasComponent } from '../Schemas/Schemas';
 
 interface AsyncAPIState {
@@ -131,10 +131,10 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                   }
                 />
               )}
-              {concatenatedConfig.show.channels && <OperationsComponent />}
+              {concatenatedConfig.show.channels && <Operations />}
               {validatedSchema.components && (
                 <section className={bemClasses.element(`components`)}>
-                  {concatenatedConfig.show.messages && <MessagesComponent />}
+                  {concatenatedConfig.show.messages && <Messages />}
                   {concatenatedConfig.show.schemas && (
                     <SchemasComponent
                       expand={
@@ -159,7 +159,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
         parserOptions,
       );
       this.setState({
-        validatedSchema: parsedFromUrl.data, // this.beautifySchema(parsedFromUrl.data),
+        validatedSchema: parsedFromUrl.data,
         asyncapi: parsedFromUrl.asyncapi,
         error: parsedFromUrl.error,
       });
@@ -168,18 +168,11 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
 
     const parsed = await this.parser.parse(schema, parserOptions);
     this.setState({
-      validatedSchema: parsed.data, // this.beautifySchema(parsed.data),
+      validatedSchema: parsed.data,
       asyncapi: parsed.asyncapi,
       error: parsed.error,
     });
   }
-
-  // private beautifySchema(schema: NullableAsyncApi): NullableAsyncApi {
-  //   if (!schema) {
-  //     return null;
-  //   }
-  //   return beautifier.beautify(schema);
-  // }
 }
 
 export default AsyncApiComponent;

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -18,7 +18,8 @@ import { ErrorComponent } from '../Error/Error';
 import { InfoComponent } from '../Info/Info';
 import { ChannelsComponent } from '../Channels/Channels';
 import { ServersComponent } from '../Servers/Servers';
-import { MessagesComponent } from '../Messages/Messages';
+// import { MessagesComponent } from '../Messages/Messages';
+import { MessagesComponent } from '../Messages/NewMessages';
 import { SchemasComponent } from '../Schemas/Schemas';
 
 interface AsyncAPIState {
@@ -123,7 +124,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                 <ErrorComponent error={error} />
               )}
               {concatenatedConfig.show.info && <InfoComponent />}
-              {concatenatedConfig.show.servers && (
+              {/* {concatenatedConfig.show.servers && (
                 <ServersComponent
                   expand={
                     concatenatedConfig.expand &&
@@ -138,15 +139,15 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                     concatenatedConfig.expand.channels
                   }
                 />
-              )}
+              )} */}
               {validatedSchema.components && (
                 <section className={bemClasses.element(`components`)}>
                   {concatenatedConfig.show.messages && (
                     <MessagesComponent
-                      expand={
-                        concatenatedConfig.expand &&
-                        concatenatedConfig.expand.messages
-                      }
+                    // expand={
+                    //   concatenatedConfig.expand &&
+                    //   concatenatedConfig.expand.messages
+                    // }
                     />
                   )}
                   {concatenatedConfig.show.schemas && (

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -19,6 +19,7 @@ import { InfoComponent } from '../Info/Info';
 import { ChannelsComponent } from '../Channels/Channels';
 import { ServersComponent } from '../Servers/Servers';
 // import { MessagesComponent } from '../Messages/Messages';
+import { OperationsComponent } from '../Channels/NewOperations';
 import { MessagesComponent } from '../Messages/NewMessages';
 import { SchemasComponent } from '../Schemas/Schemas';
 
@@ -140,6 +141,14 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                   }
                 />
               )} */}
+              {concatenatedConfig.show.channels && (
+                <OperationsComponent
+                // expand={
+                //   concatenatedConfig.expand &&
+                //   concatenatedConfig.expand.channels
+                // }
+                />
+              )}
               {validatedSchema.components && (
                 <section className={bemClasses.element(`components`)}>
                   {concatenatedConfig.show.messages && (

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -159,7 +159,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
         parserOptions,
       );
       this.setState({
-        validatedSchema: parsedFromUrl.data, //this.beautifySchema(parsedFromUrl.data),
+        validatedSchema: parsedFromUrl.data, // this.beautifySchema(parsedFromUrl.data),
         asyncapi: parsedFromUrl.asyncapi,
         error: parsedFromUrl.error,
       });
@@ -168,7 +168,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
 
     const parsed = await this.parser.parse(schema, parserOptions);
     this.setState({
-      validatedSchema: parsed.data, //this.beautifySchema(parsed.data),
+      validatedSchema: parsed.data, // this.beautifySchema(parsed.data),
       asyncapi: parsed.asyncapi,
       error: parsed.error,
     });

--- a/library/src/containers/AsyncApi/AsyncApi.tsx
+++ b/library/src/containers/AsyncApi/AsyncApi.tsx
@@ -10,15 +10,13 @@ import {
   PropsSchema,
 } from '../../types';
 import { ConfigInterface, defaultConfig } from '../../config';
-import { beautifier, bemClasses, stateHelpers, Parser } from '../../helpers';
+import { bemClasses, stateHelpers, Parser } from '../../helpers';
 import { CSS_PREFIX } from '../../constants';
 import { useSpec, useExpandedContext, useChangeHashContext } from '../../store';
 
 import { ErrorComponent } from '../Error/Error';
 import { InfoComponent } from '../Info/Info';
-import { ChannelsComponent } from '../Channels/Channels';
 import { ServersComponent } from '../Servers/Servers';
-// import { MessagesComponent } from '../Messages/Messages';
 import { OperationsComponent } from '../Channels/NewOperations';
 import { MessagesComponent } from '../Messages/NewMessages';
 import { SchemasComponent } from '../Schemas/Schemas';
@@ -125,7 +123,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                 <ErrorComponent error={error} />
               )}
               {concatenatedConfig.show.info && <InfoComponent />}
-              {/* {concatenatedConfig.show.servers && (
+              {concatenatedConfig.show.servers && (
                 <ServersComponent
                   expand={
                     concatenatedConfig.expand &&
@@ -133,32 +131,10 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
                   }
                 />
               )}
-              {concatenatedConfig.show.channels && (
-                <ChannelsComponent
-                  expand={
-                    concatenatedConfig.expand &&
-                    concatenatedConfig.expand.channels
-                  }
-                />
-              )} */}
-              {concatenatedConfig.show.channels && (
-                <OperationsComponent
-                // expand={
-                //   concatenatedConfig.expand &&
-                //   concatenatedConfig.expand.channels
-                // }
-                />
-              )}
+              {concatenatedConfig.show.channels && <OperationsComponent />}
               {validatedSchema.components && (
                 <section className={bemClasses.element(`components`)}>
-                  {concatenatedConfig.show.messages && (
-                    <MessagesComponent
-                    // expand={
-                    //   concatenatedConfig.expand &&
-                    //   concatenatedConfig.expand.messages
-                    // }
-                    />
-                  )}
+                  {concatenatedConfig.show.messages && <MessagesComponent />}
                   {concatenatedConfig.show.schemas && (
                     <SchemasComponent
                       expand={
@@ -183,7 +159,7 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
         parserOptions,
       );
       this.setState({
-        validatedSchema: this.beautifySchema(parsedFromUrl.data),
+        validatedSchema: parsedFromUrl.data, //this.beautifySchema(parsedFromUrl.data),
         asyncapi: parsedFromUrl.asyncapi,
         error: parsedFromUrl.error,
       });
@@ -192,18 +168,18 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
 
     const parsed = await this.parser.parse(schema, parserOptions);
     this.setState({
-      validatedSchema: this.beautifySchema(parsed.data),
+      validatedSchema: parsed.data, //this.beautifySchema(parsed.data),
       asyncapi: parsed.asyncapi,
       error: parsed.error,
     });
   }
 
-  private beautifySchema(schema: NullableAsyncApi): NullableAsyncApi {
-    if (!schema) {
-      return null;
-    }
-    return beautifier.beautify(schema);
-  }
+  // private beautifySchema(schema: NullableAsyncApi): NullableAsyncApi {
+  //   if (!schema) {
+  //     return null;
+  //   }
+  //   return beautifier.beautify(schema);
+  // }
 }
 
 export default AsyncApiComponent;

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Channel, Operation } from '@asyncapi/parser';
+import { Channel, Operation as OperationType } from '@asyncapi/parser';
 
-import { MessageComponent } from '../Messages/NewMessage';
+import { Message } from '../Messages/NewMessage';
 import { SchemaComponent } from '../Schemas/NewSchema';
 import { Markdown, Tags } from '../../components';
 
@@ -9,19 +9,20 @@ import { SchemaHelpers } from '../../helpers';
 import { PayloadType } from '../../types';
 
 interface Props {
-  operationType: PayloadType;
-  operation: Operation;
+  type: PayloadType;
+  operation: OperationType;
   channelName: string;
   channel: Channel;
 }
 
-export const OperationComponent: React.FunctionComponent<Props> = ({
-  operationType = PayloadType.PUBLISH,
+export const Operation: React.FunctionComponent<Props> = ({
+  type = PayloadType.PUBLISH,
   operation,
   channelName,
   channel,
 }) => {
   const parameters = SchemaHelpers.parametersToSchema(channel.parameters());
+  const operationSummary = operation.summary();
 
   return (
     <div className="center-block p-8">
@@ -29,13 +30,13 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
         <h3 className="font-mono text-base">
           <span
             className={`font-mono border uppercase p-1 rounded ${
-              operationType === PayloadType.PUBLISH
+              type === PayloadType.PUBLISH
                 ? 'border-blue-600 text-blue-500'
                 : 'border-green-600 text-green-600'
             }`}
-            title={operationType}
+            title={type}
           >
-            {operationType === PayloadType.PUBLISH ? 'PUB' : 'SUB'}
+            {type === PayloadType.PUBLISH ? 'PUB' : 'SUB'}
           </span>{' '}
           <span>{channelName}</span>
         </h3>
@@ -53,7 +54,9 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
       )}
 
       <Markdown>{channel.description()}</Markdown>
-      <Markdown>{operation.summary()}</Markdown>
+      {operationSummary && (
+        <p className="text-gray-600 text-sm">{operationSummary}</p>
+      )}
       <Markdown>{operation.description()}</Markdown>
 
       {operation.hasMultipleMessages() ? (
@@ -62,13 +65,13 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
             Accepts <strong>one of</strong> the following messages:
           </p>
           {operation.messages().map((msg, idx) => (
-            <MessageComponent message={msg} index={idx} key={idx} />
+            <Message message={msg} index={idx} key={idx} />
           ))}
         </div>
       ) : (
         <div>
           <p>Accepts the following message:</p>
-          <MessageComponent message={operation.message()} />
+          <Message message={operation.message()} />
         </div>
       )}
 

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Channel, Operation } from '@asyncapi/parser';
 
 import { MessageComponent } from '../Messages/NewMessage';
+import { SchemaComponent } from '../Schemas/NewSchema';
 import { Markdown, Tags } from '../../components';
 
+import { SchemaHelpers } from '../../helpers';
 import { PayloadType } from '../../types';
 
 interface Props {
@@ -19,6 +21,8 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
   channelName,
   channel,
 }) => {
+  const parameters = SchemaHelpers.parametersToSchema(channel.parameters());
+
   return (
     <div className="center-block p-8">
       <div className="operation pt-8 pb-8">
@@ -36,6 +40,10 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
           <span>{channelName}</span>
         </h3>
       </div>
+
+      {parameters && (
+        <SchemaComponent schemaName="Parameters" schema={parameters} />
+      )}
 
       <Markdown>{channel.description()}</Markdown>
       <Markdown>{operation.summary()}</Markdown>

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Channel, Operation } from '@asyncapi/parser';
+
+import { MessageComponent } from '../Messages/NewMessage';
+import { Markdown, Tags } from '../../components';
+
+import { PayloadType } from '../../types';
+
+interface Props {
+  operationType: PayloadType;
+  operation: Operation;
+  channelName: string;
+  channel: Channel;
+}
+
+export const OperationComponent: React.FunctionComponent<Props> = ({
+  operationType = PayloadType.PUBLISH,
+  operation,
+  channelName,
+  channel,
+}) => {
+  return (
+    <div className="center-block p-8">
+      <div className="operation pt-8 pb-8">
+        <h3 className="font-mono text-base">
+          <span
+            className={`font-mono border uppercase p-1 rounded ${
+              operationType === PayloadType.PUBLISH
+                ? 'border-blue-600 text-blue-500'
+                : 'border-green-600 text-green-600'
+            }`}
+            title={operationType}
+          >
+            {operationType === PayloadType.PUBLISH ? 'PUB' : 'SUB'}
+          </span>{' '}
+          <span>{channelName}</span>
+        </h3>
+      </div>
+
+      <Markdown>{channel.description()}</Markdown>
+      <Markdown>{operation.summary()}</Markdown>
+      <Markdown>{operation.description()}</Markdown>
+
+      {operation.hasMultipleMessages() ? (
+        <>
+          <p>
+            Accepts <strong>one of</strong> the following messages:
+          </p>
+          {operation.messages().map((msg, idx) => (
+            <MessageComponent message={msg} index={idx} />
+          ))}
+        </>
+      ) : (
+        <>
+          <p>Accepts the following message:</p>
+          <MessageComponent message={operation.message()} />
+        </>
+      )}
+
+      <Tags tags={operation.tags()} />
+    </div>
+  );
+};

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -42,7 +42,14 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
       </div>
 
       {parameters && (
-        <SchemaComponent schemaName="Parameters" schema={parameters} />
+        <SchemaComponent
+          schemaName="Parameters"
+          schema={parameters}
+          notRender={{
+            rootType: false,
+            additionalInfo: false,
+          }}
+        />
       )}
 
       <Markdown>{channel.description()}</Markdown>
@@ -50,19 +57,19 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
       <Markdown>{operation.description()}</Markdown>
 
       {operation.hasMultipleMessages() ? (
-        <>
+        <div>
           <p>
             Accepts <strong>one of</strong> the following messages:
           </p>
           {operation.messages().map((msg, idx) => (
             <MessageComponent message={msg} index={idx} key={idx} />
           ))}
-        </>
+        </div>
       ) : (
-        <>
+        <div>
           <p>Accepts the following message:</p>
           <MessageComponent message={operation.message()} />
-        </>
+        </div>
       )}
 
       <Tags tags={operation.tags()} />

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -55,7 +55,7 @@ export const OperationComponent: React.FunctionComponent<Props> = ({
             Accepts <strong>one of</strong> the following messages:
           </p>
           {operation.messages().map((msg, idx) => (
-            <MessageComponent message={msg} index={idx} />
+            <MessageComponent message={msg} index={idx} key={idx} />
           ))}
         </>
       ) : (

--- a/library/src/containers/Channels/NewOperations.tsx
+++ b/library/src/containers/Channels/NewOperations.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { OperationComponent } from './NewOperation';
+import { Toggle } from '../../components';
+
+import { bemClasses } from '../../helpers';
+import { useSpec } from '../../store';
+import { PayloadType } from '../../types';
+import { CONTAINER_LABELS, CHANNELS_TEXT } from '../../constants';
+
+export const OperationsComponent: React.FunctionComponent = () => {
+  const channels = useSpec().channels();
+
+  if (!Object.keys(channels).length) {
+    return null;
+  }
+
+  const className = CONTAINER_LABELS.CHANNELS;
+  const header = <h2>{CHANNELS_TEXT}</h2>;
+
+  const operationsList: React.ReactNodeArray = [];
+  Object.entries(channels).forEach(([channelName, channel]) => {
+    if (channel.hasPublish()) {
+      operationsList.push(
+        <li key={channelName}>
+          <OperationComponent
+            operationType={PayloadType.PUBLISH}
+            operation={channel.publish()}
+            channelName={channelName}
+            channel={channel}
+          />
+        </li>,
+      );
+    }
+    if (channel.hasSubscribe()) {
+      operationsList.push(
+        <li key={channelName}>
+          <OperationComponent
+            operationType={PayloadType.SUBSCRIBE}
+            operation={channel.subscribe()}
+            channelName={channelName}
+            channel={channel}
+          />
+        </li>,
+      );
+    }
+  });
+
+  return (
+    <section
+      className={bemClasses.element(className)}
+      id={bemClasses.identifier([className])}
+    >
+      <Toggle
+        header={header}
+        className={className}
+        expanded={true}
+        // expanded={expand && expand.root}
+        label={CONTAINER_LABELS.CHANNELS}
+        toggleInState={true}
+      >
+        <div className="operations pb-8">
+          <ul>{operationsList}</ul>
+        </div>
+      </Toggle>
+    </section>
+  );
+};

--- a/library/src/containers/Channels/NewOperations.tsx
+++ b/library/src/containers/Channels/NewOperations.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { OperationComponent } from './NewOperation';
+import { Operation } from './NewOperation';
 import { Toggle } from '../../components';
 
 import { bemClasses } from '../../helpers';
@@ -8,7 +8,7 @@ import { useSpec } from '../../store';
 import { PayloadType } from '../../types';
 import { CONTAINER_LABELS, CHANNELS_TEXT } from '../../constants';
 
-export const OperationsComponent: React.FunctionComponent = () => {
+export const Operations: React.FunctionComponent = () => {
   const channels = useSpec().channels();
 
   if (!Object.keys(channels).length) {
@@ -23,8 +23,8 @@ export const OperationsComponent: React.FunctionComponent = () => {
     if (channel.hasPublish()) {
       operationsList.push(
         <li key={channelName}>
-          <OperationComponent
-            operationType={PayloadType.PUBLISH}
+          <Operation
+            type={PayloadType.PUBLISH}
             operation={channel.publish()}
             channelName={channelName}
             channel={channel}
@@ -35,8 +35,8 @@ export const OperationsComponent: React.FunctionComponent = () => {
     if (channel.hasSubscribe()) {
       operationsList.push(
         <li key={channelName}>
-          <OperationComponent
-            operationType={PayloadType.SUBSCRIBE}
+          <Operation
+            type={PayloadType.SUBSCRIBE}
             operation={channel.subscribe()}
             channelName={channelName}
             channel={channel}

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -79,7 +79,8 @@ export const MessagesComponent: React.FunctionComponent<Props> = ({
     <Toggle
       header={header}
       className={className}
-      expanded={expand && expand.root}
+      expanded={true}
+      // expanded={expand && expand.root}
       label={CONTAINER_LABELS.MESSAGES}
       toggleInState={true}
     >

--- a/library/src/containers/Messages/NewMessage.tsx
+++ b/library/src/containers/Messages/NewMessage.tsx
@@ -6,7 +6,7 @@ import { Markdown, Tags } from '../../components';
 
 interface Props {
   message: Message;
-  index?: number;
+  index?: number | string;
 }
 
 export const MessageComponent: React.FunctionComponent<Props> = ({

--- a/library/src/containers/Messages/NewMessage.tsx
+++ b/library/src/containers/Messages/NewMessage.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
-import { Message } from '@asyncapi/parser';
+import { Message as MessageType } from '@asyncapi/parser';
 
 import { SchemaComponent } from '../Schemas/NewSchema';
 import { Markdown, Tags } from '../../components';
 
 interface Props {
-  message: Message;
+  message: MessageType;
   index?: number | string;
 }
 
-export const MessageComponent: React.FunctionComponent<Props> = ({
-  message,
-  index,
-}) => {
+export const Message: React.FunctionComponent<Props> = ({ message, index }) => {
   const title = message.title();
   const summary = message.summary();
 

--- a/library/src/containers/Messages/NewMessage.tsx
+++ b/library/src/containers/Messages/NewMessage.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Message } from '@asyncapi/parser';
+
+import { SchemaComponent } from '../Schemas/NewSchema';
+import { Markdown, Tags } from '../../components';
+
+interface Props {
+  message: Message;
+  index?: number;
+}
+
+export const MessageComponent: React.FunctionComponent<Props> = ({
+  message,
+  index,
+}) => {
+  const title = message.title();
+  const summary = message.summary();
+
+  const payload = message.payload();
+  const headers = message.headers();
+
+  const correlationId = message.correlationId();
+
+  return (
+    <div className="bg-gray-200 rounded p-4 mt-2">
+      <div className="text-sm text-gray-700 mb-2">
+        {index !== undefined && (
+          <span className="text-gray-700 font-bold mr-2">#{index}</span>
+        )}
+        {title && <span>{title}</span>}
+        <span className="border text-orange-600 rounded text-s py-0 px-2">
+          {message.uid()}
+        </span>
+      </div>
+
+      {summary && <p className="text-gray-600 text-sm">{summary}</p>}
+
+      {correlationId && (
+        <div className="border border-gray-400 bg-gray-200 rounded p-4 mt-2">
+          <div className="text-sm text-gray-700 mb-2">
+            Correlation ID
+            <span className="border text-orange-600 rounded text-xs ml-3 py-0 px-2">
+              {correlationId.location()}
+            </span>
+          </div>
+          <Markdown>{correlationId.description()}</Markdown>
+        </div>
+      )}
+
+      <Markdown>{message.description()}</Markdown>
+
+      {payload && <SchemaComponent schemaName="Payload" schema={payload} />}
+      {headers && <SchemaComponent schemaName="Headers" schema={headers} />}
+
+      <Tags tags={message.tags()} />
+    </div>
+  );
+};

--- a/library/src/containers/Messages/NewMessages.tsx
+++ b/library/src/containers/Messages/NewMessages.tsx
@@ -19,10 +19,10 @@ export const MessagesComponent: React.FunctionComponent = () => {
 
   const messagesList = (
     <ul>
-      {Array.from(messages).map(([key, msg]) => {
+      {Array.from(messages).map(([key, msg], idx) => {
         return (
           <li key={key}>
-            <MessageComponent message={msg} index={key} />
+            <MessageComponent message={msg} index={idx + 1} />
           </li>
         );
       })}

--- a/library/src/containers/Messages/NewMessages.tsx
+++ b/library/src/containers/Messages/NewMessages.tsx
@@ -22,7 +22,7 @@ export const MessagesComponent: React.FunctionComponent = () => {
       {Array.from(messages).map(([key, msg]) => {
         return (
           <li key={key}>
-            <MessageComponent message={msg} />
+            <MessageComponent message={msg} index={key} />
           </li>
         );
       })}
@@ -39,7 +39,7 @@ export const MessagesComponent: React.FunctionComponent = () => {
         className={className}
         expanded={true}
         // expanded={expand && expand.root}
-        label={CONTAINER_LABELS.SCHEMAS}
+        label={CONTAINER_LABELS.MESSAGES}
         toggleInState={true}
       >
         <div className="all-messages pb-8">{messagesList}</div>

--- a/library/src/containers/Messages/NewMessages.tsx
+++ b/library/src/containers/Messages/NewMessages.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { MessageComponent } from './NewMessage';
+import { Message } from './NewMessage';
 import { Toggle } from '../../components';
 
 import { bemClasses } from '../../helpers';
 import { useSpec } from '../../store';
 import { CONTAINER_LABELS, MESSAGES_TEXT } from '../../constants';
 
-export const MessagesComponent: React.FunctionComponent = () => {
+export const Messages: React.FunctionComponent = () => {
   const messages = useSpec().allMessages();
 
   if (!messages.size) {
@@ -21,7 +21,7 @@ export const MessagesComponent: React.FunctionComponent = () => {
     <ul>
       {Array.from(messages).map(([key, msg], idx) => (
         <li key={key}>
-          <MessageComponent message={msg} index={idx + 1} key={idx} />
+          <Message message={msg} index={idx + 1} key={idx} />
         </li>
       ))}
     </ul>

--- a/library/src/containers/Messages/NewMessages.tsx
+++ b/library/src/containers/Messages/NewMessages.tsx
@@ -19,13 +19,11 @@ export const MessagesComponent: React.FunctionComponent = () => {
 
   const messagesList = (
     <ul>
-      {Array.from(messages).map(([key, msg], idx) => {
-        return (
-          <li key={key}>
-            <MessageComponent message={msg} index={idx + 1} />
-          </li>
-        );
-      })}
+      {Array.from(messages).map(([key, msg], idx) => (
+        <li key={key}>
+          <MessageComponent message={msg} index={idx + 1} key={idx} />
+        </li>
+      ))}
     </ul>
   );
 

--- a/library/src/containers/Messages/NewMessages.tsx
+++ b/library/src/containers/Messages/NewMessages.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { MessageComponent } from './NewMessage';
+import { Toggle } from '../../components';
+
+import { bemClasses } from '../../helpers';
+import { useSpec } from '../../store';
+import { CONTAINER_LABELS, MESSAGES_TEXT } from '../../constants';
+
+export const MessagesComponent: React.FunctionComponent = () => {
+  const messages = useSpec().allMessages();
+
+  if (!messages.size) {
+    return null;
+  }
+
+  const className = CONTAINER_LABELS.SCHEMAS;
+  const header = <h2>{MESSAGES_TEXT}</h2>;
+
+  const messagesList = (
+    <ul>
+      {Array.from(messages).map(([key, msg]) => {
+        return (
+          <li key={key}>
+            <MessageComponent message={msg} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  return (
+    <section
+      className={bemClasses.element(className)}
+      id={bemClasses.identifier([className])}
+    >
+      <Toggle
+        header={header}
+        className={className}
+        expanded={true}
+        // expanded={expand && expand.root}
+        label={CONTAINER_LABELS.SCHEMAS}
+        toggleInState={true}
+      >
+        <div className="all-messages pb-8">{messagesList}</div>
+      </Toggle>
+    </section>
+  );
+};

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -4,11 +4,17 @@ import { Schema } from '@asyncapi/parser';
 import { Chevron, Markdown } from '../../components';
 import { SchemaHelpers } from '../../helpers';
 
+interface NotRenderProps {
+  rootType?: boolean;
+  additionalInfo?: boolean;
+}
+
 interface Props {
   schemaName?: string;
   schema?: Schema;
   required?: boolean;
   isCircular?: boolean;
+  notRender?: NotRenderProps;
 }
 
 export const SchemaComponent: React.FunctionComponent<Props> = ({
@@ -16,6 +22,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
   schema,
   required = false,
   isCircular = false,
+  notRender = {},
 }) => {
   const [expand, setExpand] = useState(false);
 
@@ -25,6 +32,9 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
 
   const constraints = SchemaHelpers.humanizeConstraints(schema);
   const isExpandable = SchemaHelpers.isExpandable(schema);
+
+  const renderType = notRender.rootType !== false;
+  const renderAdditionalInfo = notRender.additionalInfo !== false;
 
   return (
     <div
@@ -56,7 +66,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
         ) : (
           <div>
             <div className="capitalize text-sm text-teal-500 font-bold">
-              {SchemaHelpers.toSchemaType(schema)}
+              {renderType && SchemaHelpers.toSchemaType(schema)}
               <div className="inline-block">
                 {schema.format() && (
                   <span
@@ -145,7 +155,10 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
 
       {isCircular || !isExpandable ? null : expand ? (
         <div className="json-schema">
-          <SchemaProperties schema={schema} />
+          <SchemaProperties
+            schema={schema}
+            renderAdditionalInfo={renderAdditionalInfo}
+          />
           <SchemaItems schema={schema} />
 
           {schema.oneOf() &&
@@ -174,10 +187,12 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
 
 interface SchemaPropertiesProps {
   schema: Schema;
+  renderAdditionalInfo?: boolean;
 }
 
 const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
   schema,
+  renderAdditionalInfo,
 }) => {
   const properties = schema.properties() || {};
   if (!Object.keys(properties)) {
@@ -198,7 +213,7 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
           key={propertyName}
         />
       ))}
-      <SchemaAdditionalProperties schema={schema} />
+      {renderAdditionalInfo && <SchemaAdditionalProperties schema={schema} />}
     </>
   );
 };

--- a/library/src/containers/Schemas/Schemas.tsx
+++ b/library/src/containers/Schemas/Schemas.tsx
@@ -32,9 +32,9 @@ export const SchemasComponent: React.FunctionComponent<Props> = ({
           className={bemClasses.element(`${className}-list-item`)}
         >
           <SchemaComponent
-            // name={key}
+            schemaName={schemaName}
             schema={schema}
-            // schemaName={schemaName}
+            // name={key}
             // toggle={true}
             // toggleExpand={expand && expand.elements}
           />

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@asyncapi/parser';
+import { Schema, ChannelParameter } from '@asyncapi/parser';
 
 export class SchemaHelpers {
   static toSchemaType(schema: Schema): string {
@@ -72,6 +72,28 @@ export class SchemaHelpers {
   }
 
   static isExpandable(schema: Schema): boolean {
+    let type = schema.type();
+    type = Array.isArray(type) ? type : [type];
+    if (type.includes('object') || type.includes('array')) {
+      return true;
+    }
+
+    if (
+      schema.oneOf() ||
+      schema.anyOf() ||
+      schema.allOf() ||
+      Object.keys(schema.properties()).length ||
+      schema.additionalProperties() ||
+      schema.items() ||
+      schema.additionalItems()
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  static parametersToSchema(schema: Schema): boolean {
     let type = schema.type();
     type = Array.isArray(type) ? type : [type];
     if (type.includes('object') || type.includes('array')) {

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -119,6 +119,23 @@ components:
       name: dimLight
       title: Dim light
       summary: Command a particular streetlight to dim the lights.
+      correlationId:
+        $ref: "#/components/correlationIds/sentAtCorrelator"
+      tags:
+        - name: oparation-tag1
+          externalDocs:
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: oparation-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: oparation-tag3
+        - name: oparation-tag4
+          description: Description 4
+        - name: oparation-tag5
+          externalDocs:
+            url: "https://www.asyncapi.com/"
       traits:
         - $ref: '#/components/messageTraits/commonHeaders'
       payload:
@@ -234,6 +251,11 @@ components:
       description: The ID of the streetlight.
       schema:
         type: string
+
+  correlationIds:
+    sentAtCorrelator:
+      description: Data from message payload used as correlation ID
+      location: $message.payload#/sentAt
 
   messageTraits:
     commonHeaders:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Unify `Messages` and `Operations` components,
- styles as in previous PR with new `Schema` component is not related to this PR but to https://github.com/asyncapi/shape-up-process/issues/86 task,
- render `correlationId` and `tags` in messages and operations.

> **NOTE**: there are still `Servers` and `Info` to rewrite, as well as custom extensions and bindings. Then we can start styling :)

Examples:

![image](https://user-images.githubusercontent.com/20404945/112453908-6ff68f00-8d58-11eb-82c8-3174f2f4a533.png)

![image](https://user-images.githubusercontent.com/20404945/112323421-120f6c00-8cb2-11eb-9f93-4393bb84ace1.png)

**Related issue(s)**
Part of https://github.com/asyncapi/shape-up-process/issues/87
