### PR TITLE
refactor: unify bindings and extensions

### DIFF
--- a/library/src/containers/Bindings/Bindings.tsx
+++ b/library/src/containers/Bindings/Bindings.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { SchemaComponent } from '../Schemas/NewSchema';
+
+import { SchemaHelpers } from '../../helpers';
+
+interface Props {
+  name?: string;
+  bindings: any;
+}
+
+export const Bindings: React.FunctionComponent<Props> = ({
+  name = 'Bindings',
+  bindings,
+}) => {
+  if (!bindings || !Object.keys(bindings).length) {
+    return null;
+  }
+  const schema = SchemaHelpers.jsonToSchema(bindings);
+
+  return <SchemaComponent schemaName={name} schema={schema} />;
+};

--- a/library/src/containers/Channels/NewOperation.tsx
+++ b/library/src/containers/Channels/NewOperation.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Channel, Operation as OperationType } from '@asyncapi/parser';
 
+import { Bindings } from '../Bindings/Bindings';
 import { Message } from '../Messages/NewMessage';
 import { SchemaComponent } from '../Schemas/NewSchema';
 import { Markdown, Tags } from '../../components';
@@ -46,10 +47,7 @@ export const Operation: React.FunctionComponent<Props> = ({
         <SchemaComponent
           schemaName="Parameters"
           schema={parameters}
-          notRender={{
-            rootType: false,
-            additionalInfo: false,
-          }}
+          expanded={true}
         />
       )}
 
@@ -73,6 +71,13 @@ export const Operation: React.FunctionComponent<Props> = ({
           <p>Accepts the following message:</p>
           <Message message={operation.message()} />
         </div>
+      )}
+
+      {operation.hasBindings() && (
+        <Bindings name="Operation Bindings" bindings={operation.bindings()} />
+      )}
+      {channel.hasBindings() && (
+        <Bindings name="Channel Bindings" bindings={channel.bindings()} />
       )}
 
       <Tags tags={operation.tags()} />

--- a/library/src/containers/Extensions/Extensions.tsx
+++ b/library/src/containers/Extensions/Extensions.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { SchemaComponent } from '../Schemas/NewSchema';
+
+import { SchemaHelpers } from '../../helpers';
+
+interface Props {
+  name?: string;
+  item: any;
+}
+
+export const Extensions: React.FunctionComponent<Props> = ({
+  name = 'Extensions',
+  item,
+}) => {
+  const extensions = SchemaHelpers.getCustomExtensions(item);
+  if (!extensions || !Object.keys(extensions).length) {
+    return null;
+  }
+
+  const schema = SchemaHelpers.jsonToSchema(extensions);
+  return <SchemaComponent schemaName={name} schema={schema} />;
+};

--- a/library/src/containers/Messages/NewMessage.tsx
+++ b/library/src/containers/Messages/NewMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Message as MessageType } from '@asyncapi/parser';
 
+import { Bindings } from '../Bindings/Bindings';
 import { SchemaComponent } from '../Schemas/NewSchema';
 import { Markdown, Tags } from '../../components';
 
@@ -48,6 +49,8 @@ export const Message: React.FunctionComponent<Props> = ({ message, index }) => {
 
       {payload && <SchemaComponent schemaName="Payload" schema={payload} />}
       {headers && <SchemaComponent schemaName="Headers" schema={headers} />}
+
+      {message.hasBindings() && <Bindings bindings={message.bindings()} />}
 
       <Tags tags={message.tags()} />
     </div>

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -11,6 +11,7 @@ interface Props {
   required?: boolean;
   isCircular?: boolean;
   isPatternProperty?: boolean;
+  isPropertyName?: boolean;
   expanded?: boolean;
 }
 
@@ -20,6 +21,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
   required = false,
   isCircular = false,
   isPatternProperty = false,
+  isPropertyName = false,
   expanded = false,
 }) => {
   const [expand, setExpand] = useState(expanded);
@@ -42,7 +44,11 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
     >
       <div className="flex property">
         <div className="pr-4" style={{ minWidth: '25%' }}>
-          <span className="text-sm italic text-gray-500">
+          <span
+            className={`text-sm text-gray-500 ${
+              isPropertyName ? 'italic' : ''
+            }`}
+          >
             {schemaName || schema.uid()}
           </span>
           {isExpandable && (
@@ -173,7 +179,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
               {schema.propertyNames() && (
                 <SchemaComponent
                   schema={schema.propertyNames()}
-                  schemaName="Property names must adhere:"
+                  schemaName="Property names must adhere to:"
                 />
               )}
 
@@ -213,7 +219,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
               {schema.not() && (
                 <SchemaComponent
                   schema={schema.not()}
-                  schemaName="Cannot adhere:"
+                  schemaName="Cannot adhere to:"
                 />
               )}
 
@@ -221,6 +227,25 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
                 <SchemaComponent
                   schema={schema.contains()}
                   schemaName="Array must contain at least one of:"
+                />
+              )}
+
+              {schema.if() && (
+                <SchemaComponent
+                  schema={schema.if()}
+                  schemaName="If schema adheres to:"
+                />
+              )}
+              {schema.then() && (
+                <SchemaComponent
+                  schema={schema.then()}
+                  schemaName="Then it must adhere to:"
+                />
+              )}
+              {schema.else() && (
+                <SchemaComponent
+                  schema={schema.else()}
+                  schemaName="Otherwise it must adhere to:"
                 />
               )}
 
@@ -258,6 +283,7 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
           schemaName={propertyName}
           required={required.includes(propertyName)}
           isCircular={circularProps.includes(propertyName)}
+          isPropertyName={true}
           key={propertyName}
         />
       ))}
@@ -267,6 +293,7 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
           schemaName={propertyName}
           isCircular={circularProps.includes(propertyName)}
           isPatternProperty={true}
+          isPropertyName={true}
           key={propertyName}
         />
       ))}
@@ -308,7 +335,7 @@ const AdditionalProperties: React.FunctionComponent<AdditionalPropertiesProps> =
   }
   return (
     <SchemaComponent
-      schemaName="Additional properties must adhere:"
+      schemaName="Additional properties must adhere to:"
       schema={additionalProperties}
     />
   );
@@ -378,7 +405,7 @@ const AdditionalItems: React.FunctionComponent<AdditionalItemsProps> = ({
   }
   return (
     <SchemaComponent
-      schemaName="Additional items must adhere:"
+      schemaName="Additional items must adhere to:"
       schema={additionalItems}
     />
   );

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -11,7 +11,7 @@ interface Props {
   required?: boolean;
   isCircular?: boolean;
   isPatternProperty?: boolean;
-  isPropertyName?: boolean;
+  isProperty?: boolean;
   expanded?: boolean;
 }
 
@@ -21,7 +21,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
   required = false,
   isCircular = false,
   isPatternProperty = false,
-  isPropertyName = false,
+  isProperty = false,
   expanded = false,
 }) => {
   const [expand, setExpand] = useState(expanded);
@@ -45,9 +45,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
       <div className="flex property">
         <div className="pr-4" style={{ minWidth: '25%' }}>
           <span
-            className={`text-sm text-gray-500 ${
-              isPropertyName ? 'italic' : ''
-            }`}
+            className={`text-sm text-gray-500 ${isProperty ? 'italic' : ''}`}
           >
             {schemaName || schema.uid()}
           </span>
@@ -282,7 +280,7 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
           schemaName={propertyName}
           required={required.includes(propertyName)}
           isCircular={circularProps.includes(propertyName)}
-          isPropertyName={true}
+          isProperty={true}
           key={propertyName}
         />
       ))}
@@ -292,7 +290,7 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
           schemaName={propertyName}
           isCircular={circularProps.includes(propertyName)}
           isPatternProperty={true}
-          isPropertyName={true}
+          isProperty={true}
           key={propertyName}
         />
       ))}

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -32,7 +32,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
   const isExpandable = SchemaHelpers.isExpandable(schema);
 
   const renderType = schema.ext(SchemaHelpers.extRenderType) !== false;
-  const hasValue = schema.ext(SchemaHelpers.exthasValue) === true;
+  const rawValue = schema.ext(SchemaHelpers.extRawValue) === true;
 
   return (
     <div
@@ -70,7 +70,7 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
               [CIRCULAR]
             </div>
           </div>
-        ) : hasValue ? (
+        ) : rawValue ? (
           <div>
             <div className="text-sm text-teal-500 font-bold">
               {schema.const()}
@@ -170,6 +170,13 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
         ? null
         : expand && (
             <div className="json-schema">
+              {schema.propertyNames() && (
+                <SchemaComponent
+                  schema={schema.propertyNames()}
+                  schemaName="Property names must adhere:"
+                />
+              )}
+
               <SchemaProperties schema={schema} />
               <SchemaItems schema={schema} />
 
@@ -203,16 +210,22 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
                       schemaName={`${idx}`}
                     />
                   ))}
-
               {schema.not() && (
                 <SchemaComponent
                   schema={schema.not()}
-                  schemaName="Cannot adhere"
+                  schemaName="Cannot adhere:"
                 />
               )}
 
-              <SchemaAdditionalProperties schema={schema} />
-              <SchemaAdditionalItems schema={schema} />
+              {schema.contains() && (
+                <SchemaComponent
+                  schema={schema.contains()}
+                  schemaName="Array must contain at least one of:"
+                />
+              )}
+
+              <AdditionalProperties schema={schema} />
+              <AdditionalItems schema={schema} />
 
               <Extensions item={schema} />
             </div>
@@ -261,11 +274,11 @@ const SchemaProperties: React.FunctionComponent<SchemaPropertiesProps> = ({
   );
 };
 
-interface SchemaAdditionalPropertiesProps {
+interface AdditionalPropertiesProps {
   schema: Schema;
 }
 
-const SchemaAdditionalProperties: React.FunctionComponent<SchemaAdditionalPropertiesProps> = ({
+const AdditionalProperties: React.FunctionComponent<AdditionalPropertiesProps> = ({
   schema,
 }) => {
   if (schema.ext(SchemaHelpers.extRenderAdditionalInfo) === false) {
@@ -295,7 +308,7 @@ const SchemaAdditionalProperties: React.FunctionComponent<SchemaAdditionalProper
   }
   return (
     <SchemaComponent
-      schemaName="Additional properties must adhere"
+      schemaName="Additional properties must adhere:"
       schema={additionalProperties}
     />
   );
@@ -328,11 +341,11 @@ const SchemaItems: React.FunctionComponent<SchemaItemsProps> = ({ schema }) => {
   return <SchemaComponent schema={items} schemaName={'0'} />;
 };
 
-interface SchemaAdditionalItemsProps {
+interface AdditionalItemsProps {
   schema: Schema;
 }
 
-const SchemaAdditionalItems: React.FunctionComponent<SchemaAdditionalItemsProps> = ({
+const AdditionalItems: React.FunctionComponent<AdditionalItemsProps> = ({
   schema,
 }) => {
   if (schema.ext(SchemaHelpers.extRenderAdditionalInfo) === false) {
@@ -365,7 +378,7 @@ const SchemaAdditionalItems: React.FunctionComponent<SchemaAdditionalItemsProps>
   }
   return (
     <SchemaComponent
-      schemaName="Additional items must adhere"
+      schemaName="Additional items must adhere:"
       schema={additionalItems}
     />
   );

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -176,13 +176,6 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
         ? null
         : expand && (
             <div className="json-schema">
-              {schema.propertyNames() && (
-                <SchemaComponent
-                  schema={schema.propertyNames()}
-                  schemaName="Property names must adhere to:"
-                />
-              )}
-
               <SchemaProperties schema={schema} />
               <SchemaItems schema={schema} />
 
@@ -223,6 +216,12 @@ export const SchemaComponent: React.FunctionComponent<Props> = ({
                 />
               )}
 
+              {schema.propertyNames() && (
+                <SchemaComponent
+                  schema={schema.propertyNames()}
+                  schemaName="Property names must adhere to:"
+                />
+              )}
               {schema.contains() && (
                 <SchemaComponent
                   schema={schema.contains()}

--- a/library/src/containers/Schemas/NewSchema.tsx
+++ b/library/src/containers/Schemas/NewSchema.tsx
@@ -360,12 +360,16 @@ const SchemaItems: React.FunctionComponent<SchemaItemsProps> = ({ schema }) => {
     return (
       <>
         {items.map((item, idx) => (
-          <SchemaComponent schema={item} schemaName={`${idx}`} key={idx} />
+          <SchemaComponent
+            schema={item}
+            schemaName={`${idx + 1} item:`}
+            key={idx}
+          />
         ))}
       </>
     );
   }
-  return <SchemaComponent schema={items} schemaName={'0'} />;
+  return <SchemaComponent schema={items} schemaName="Items:" />;
 };
 
 interface AdditionalItemsProps {

--- a/library/src/containers/Servers/Server.tsx
+++ b/library/src/containers/Servers/Server.tsx
@@ -80,7 +80,7 @@ export const ServerComponent: React.FunctionComponent<Props> = ({
         identifier={identifier}
         dataIdentifier={dataIdentifier}
       />
-      {serverSecurity.length && (
+      {serverSecurity && serverSecurity.length && (
         <ServerSecurityComponent
           requirements={serverSecurity}
           identifier={identifier}

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -7,10 +7,16 @@ export class SchemaHelpers {
   static extRenderAdditionalInfo = 'x-schema-private-render-additional-info';
   static extRawValue = 'x-schema-private-raw-value';
 
-  static toSchemaType(schema: Schema): string {
+  static toSchemaType(schema: Schema | boolean): string {
+    if (schema === true) {
+      return 'Any';
+    } else if (schema === false) {
+      return 'Never';
+    }
+
     let type = schema.type();
     if (Array.isArray(type)) {
-      return type.map(t => this.toType(t, schema)).join(' | ');
+      return type.map(t => this.toType(t, schema)).join(' or ');
     }
     type = this.toType(type, schema);
     const combinedType = this.toCombinedType(schema);
@@ -92,7 +98,8 @@ export class SchemaHelpers {
       Object.keys(schema.properties()).length ||
       schema.additionalProperties() ||
       schema.items() ||
-      schema.additionalItems()
+      schema.additionalItems() ||
+      schema.if()
     ) {
       return true;
     }

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -16,7 +16,7 @@ export class SchemaHelpers {
 
     let type = schema.type();
     if (Array.isArray(type)) {
-      return type.map(t => this.toType(t, schema)).join(' or ');
+      return type.map(t => this.toType(t, schema)).join(' | ');
     }
     type = this.toType(type, schema);
     const combinedType = this.toCombinedType(schema);

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -5,7 +5,7 @@ import SchemaClass from '@asyncapi/parser/lib/models/schema';
 export class SchemaHelpers {
   static extRenderType = 'x-schema-private-render-type';
   static extRenderAdditionalInfo = 'x-schema-private-render-additional-info';
-  static exthasValue = 'x-schema-private-has-value';
+  static extRawValue = 'x-schema-private-raw-value';
 
   static toSchemaType(schema: Schema): string {
     let type = schema.type();
@@ -260,7 +260,7 @@ export class SchemaHelpers {
       return {
         type: 'string',
         const: value,
-        [this.exthasValue]: true,
+        [this.extRawValue]: true,
       };
     }
     if (this.isJSONSchema(value)) {

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -88,11 +88,17 @@ export class SchemaHelpers {
       schema.oneOf() ||
       schema.anyOf() ||
       schema.allOf() ||
+      schema.not() ||
       Object.keys(schema.properties()).length ||
       schema.additionalProperties() ||
       schema.items() ||
       schema.additionalItems()
     ) {
+      return true;
+    }
+
+    const customExtensions = this.getCustomExtensions(schema);
+    if (customExtensions && Object.keys(customExtensions).length) {
       return true;
     }
 
@@ -190,21 +196,23 @@ export class SchemaHelpers {
     max: number | undefined,
     exclusiveMax: number | undefined,
   ): string | undefined {
-    const hasMin = min !== undefined || exclusiveMin !== undefined;
-    const hasMax = max !== undefined || exclusiveMax !== undefined;
+    const hasExclusiveMin = exclusiveMin !== undefined;
+    const hasMin = min !== undefined || hasExclusiveMin;
+    const hasExclusiveMax = exclusiveMax !== undefined;
+    const hasMax = max !== undefined || hasExclusiveMax;
 
     let numberRange;
     if (hasMin && hasMax) {
-      numberRange = exclusiveMin !== undefined ? '( ' : '[ ';
-      numberRange += exclusiveMin !== undefined ? exclusiveMin : min;
+      numberRange = hasExclusiveMin ? '( ' : '[ ';
+      numberRange += hasExclusiveMin ? exclusiveMin : min;
       numberRange += ' .. ';
-      numberRange += exclusiveMax !== undefined ? exclusiveMax : max;
-      numberRange += exclusiveMax !== undefined ? ' )' : ' ]';
+      numberRange += hasExclusiveMax ? exclusiveMax : max;
+      numberRange += hasExclusiveMax ? ' )' : ' ]';
     } else if (hasMin) {
-      numberRange = exclusiveMin !== undefined ? '> ' : '>= ';
+      numberRange = hasExclusiveMin ? '> ' : '>= ';
       numberRange += min;
     } else if (hasMax) {
-      numberRange = exclusiveMax !== undefined ? '< ' : '<= ';
+      numberRange = hasExclusiveMax ? '< ' : '<= ';
       numberRange += max;
     }
     return numberRange;
@@ -268,6 +276,7 @@ export class SchemaHelpers {
       [this.extRenderAdditionalInfo]: false,
     };
   }
+
   private static isJSONSchema(value: any): boolean {
     if (
       value &&

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -17,7 +17,7 @@ import {
 import { defaultConfig, parse, debounce } from './common';
 import * as specs from './specs';
 
-const defaultSchema = specs.streetlights;
+const defaultSchema = specs.dummy;
 
 interface State {
   schema: string;

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -149,10 +149,23 @@ components:
           type: integer
           minimum: 0
           description: Light intensity measured in lumens.
+          writeOnly: true
         sentAt:
           $ref: "#/components/schemas/sentAt"
       required:
         - lumens
+      x-schema-extensions-as-object:
+        type: object
+        properties:
+          prop1:
+            type: string
+          prop2:
+            type: integer
+            minimum: 0
+      x-schema-extensions-as-primitive: dummy
+      x-schema-extensions-as-array: 
+        - "item1"
+        - "item2"
     turnOnOffPayload:
       type: object
       properties:
@@ -175,6 +188,7 @@ components:
           description: Percentage to which the light should be dimmed to.
           minimum: 0
           maximum: 100
+          readOnly: true
         sentAt:
           $ref: "#/components/schemas/sentAt"
       additionalProperties: false
@@ -206,6 +220,35 @@ components:
       allOf:
         - $ref: "#/components/schemas/objectWithKey"
         - $ref: "#/components/schemas/objectWithKey2"
+
+    subscriptionStatus:
+      type: object
+      oneOf:
+        - properties:
+            channelID:
+              type: integer
+              description: ChannelID on successful subscription, applicable to public messages only.
+            channelName:
+              type: string
+              description: Channel Name on successful subscription. For payloads 'ohlc' and 'book', respective interval or depth will be added as suffix.
+        - properties:
+            errorMessage:
+              type: string
+      properties:
+        event:
+          type: string
+          const: subscriptionStatus
+        subscription:
+          type: object
+          properties:
+            depth:
+              type: string
+            interval:
+              type: string
+          required:
+            - name
+      required:
+        - event
 
   securitySchemes:
     apiKey:

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -152,6 +152,7 @@ components:
           writeOnly: true
         sentAt:
           $ref: "#/components/schemas/sentAt"
+        lol: {}
         ifElseThen:
           type: integer
           minimum: 1

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -209,6 +209,8 @@ components:
       type: [string, number]
     objectWithKey:
       type: object
+      propertyNames:
+        format: email
       properties:
         key:
           type: string
@@ -229,6 +231,10 @@ components:
       allOf:
         - $ref: "#/components/schemas/objectWithKey"
         - $ref: "#/components/schemas/objectWithKey2"
+    arrayContains: 
+      type: array
+      contains:
+        type: integer
 
     subscriptionStatus:
       type: object

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -152,6 +152,19 @@ components:
           writeOnly: true
         sentAt:
           $ref: "#/components/schemas/sentAt"
+        ifElseThen:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          if:
+            minimum: 100
+          then: 
+            multipleOf: 100
+          else:
+            if: 
+              minimum: 10
+            then: 
+              multipleOf: 10
       required:
         - lumens
       x-schema-extensions-as-object:

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -191,6 +191,15 @@ components:
           readOnly: true
         sentAt:
           $ref: "#/components/schemas/sentAt"
+        key:
+          type: integer
+          not:
+            minimum: 3
+      patternProperties:
+        ^S_:
+          type: string
+        ^I_:
+          type: integer
       additionalProperties: false
     sentAt:
       type: string


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Unify bindings and extensions:
- as previous PRs, styles will be done in https://github.com/asyncapi/shape-up-process/issues/86
- render bindings and extensions as schema,
- render missed JSON-Schema (we don't also render them in HTML-template) like: `if/then/else`, `contains`, `propertyNames`, `patternProperties`, `not`. 
 
Examples:
![image](https://user-images.githubusercontent.com/20404945/112758827-9171a800-8ff0-11eb-942c-ee9fa20b5b46.png)

Not:
![image](https://user-images.githubusercontent.com/20404945/112758919-f88f5c80-8ff0-11eb-951e-d6bf52eadd34.png)

Contains:
![image](https://user-images.githubusercontent.com/20404945/112758891-d5fd4380-8ff0-11eb-94ae-96041583b77b.png)

PropertyNames:
![image](https://user-images.githubusercontent.com/20404945/112758900-e1e90580-8ff0-11eb-930a-a2ea6e58b3fa.png)
    
**Related issue(s)**
Part of https://github.com/asyncapi/shape-up-process/issues/87