### PR TITLE
ci: fix checkout to next branch

### DIFF
--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -13,11 +13,16 @@ jobs:
     name: Generate assets and bump
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repository (@latest tag -> master branch)
+        if: "!contains(github.event.release.tag_name, 'next')"
         uses: actions/checkout@v2
         with:
-          # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
-          ref: ${{ github.event.release.target_commitish }}
+          ref: master
+      - name: Checkout repository (@next tag -> next branch)
+        if: "contains(github.event.release.tag_name, 'next')"
+        uses: actions/checkout@v2
+        with:
+          ref: next
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"

--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -11,11 +11,16 @@ jobs:
     name: Release Web-component
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (@latest tag -> master branch)
+        if: "!contains(github.event.release.tag_name, 'next')"
         uses: actions/checkout@v2
         with:
-          # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
-          ref: ${{ github.event.release.target_commitish }}
+          ref: master
+      - name: Checkout repository (@next tag -> next branch)
+        if: "contains(github.event.release.tag_name, 'next')"
+        uses: actions/checkout@v2
+        with:
+          ref: next
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
@@ -31,14 +36,14 @@ jobs:
         # When adding "bump:version" script in package.json, make sure --allow-same-version is set in case someone forgot and updated package.json manually and we want to avoide this action to fail and raise confusion
         run: VERSION=${{github.event.release.tag_name}} npm run bump:webcomp:version
       - name: Release web-component to NPM (@latest tag)
-        if: github.event.release.target_commitish == 'master'
+        if: "!contains(github.event.release.tag_name, 'next')"
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./web-component/package.json
           access: public
       - name: Release web-component to NPM (@next tag)
-        if: github.event.release.target_commitish == 'next'
+        if: "contains(github.event.release.tag_name, 'next')"
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -46,11 +51,9 @@ jobs:
           access: public
           tag: next
 
-
   playground:
     name: Release Playground
-    # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
-    if: github.event.release.target_commitish == 'master'
+    if: "!contains(github.event.release.tag_name, 'next')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

As in title. Fix checkout to `next` branch in `wc-release` and `bump` workflows. Checkout to next when in `release_tag` will contain `next` substring.