### PR TITLE
fix: strictly check if a given part of spec exists and render single message from oneOf

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,32 @@
+name: Bump package version in dependent repos
+
+on:
+  #It cannot run on release event as when release is created then version is not yet bumped in package.json
+  #This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - next
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Get version from package.json before release step
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get:version --silent)"
+      - name: Get name of package from package.json
+        id: extractname
+        run: echo "::set-output name=packname::$(npm run get:name --silent)"
+      - if: startsWith(github.event.commits[0].message, 'chore(release):')
+        name: Bumping latest version of this package in other repositories
+        uses: derberg/org-projects-dependency-manager@v1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          #This is commit message and PR title for repos where this package is in dependencies
+          commit_message_prod: 'fix: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'
+          #This is commit message and PR title for repos where this package is in devDependencies
+          commit_message_dev: 'chore: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -27,6 +27,10 @@ export const Message: React.FunctionComponent<Props> = ({
   index,
   showExamples = false,
 }) => {
+  if (!message) {
+    return null;
+  }
+
   const title = message.title();
   const summary = message.summary();
   const payload = message.payload();

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -9,6 +9,10 @@ interface Props {
 }
 
 export const MessageExample: React.FunctionComponent<Props> = ({ message }) => {
+  if (!message) {
+    return null;
+  }
+
   const payload = message.payload();
   const headers = message.headers();
 

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -111,7 +111,10 @@ export const Operation: React.FunctionComponent<Props> = ({
           <div className="mt-2">
             <p className="px-8">Accepts the following message:</p>
             <div className="mt-2">
-              <Message message={operation.message()} showExamples={true} />
+              <Message
+                message={(operation.message as any)(0)}
+                showExamples={true}
+              />
             </div>
           </div>
         )}

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -20,6 +20,10 @@ export const Operation: React.FunctionComponent<Props> = ({
   channelName,
   channel,
 }) => {
+  if (!operation) {
+    return null;
+  }
+
   const parameters = SchemaHelpers.parametersToSchema(channel.parameters());
   const operationSummary = operation.summary();
 

--- a/library/src/containers/Servers/Server.tsx
+++ b/library/src/containers/Servers/Server.tsx
@@ -15,6 +15,10 @@ export const Server: React.FunctionComponent<Props> = ({
   serverName,
   server,
 }) => {
+  if (!server) {
+    return null;
+  }
+
   const urlVariables = SchemaHelpers.serverVariablesToSchema(
     server.variables(),
   );

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import Playground from './Playground';
 
 import '@fortawesome/fontawesome-svg-core/styles.css';
-import '@asyncapi/react-component/lib/styles/fiori.css';
 import '@asyncapi/react-component/styles/default.min.css';
 import './common/icons';
 

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -1,473 +1,58 @@
 export const streetlights = `
-asyncapi: '2.0.0'
-id: 'urn:com:smartylighting:streetlights:server'
+asyncapi: 2.0.0
+id: 'https://api.apiture.com/apis/async-api-id/apiture-public-events'
 info:
-  title: Streetlights API
-  version: '1.0.0'
-  description: |
-    The Smartylighting Streetlights API allows you to remotely manage the city lights.
-
-    ### Check out its awesome features:
-
-    * Turn a specific streetlight on/off 🌃
-    * Dim a specific streetlight 😎
-    * Receive real-time information about environmental lighting conditions 📈
-
-  termsOfService: http://asyncapi.org/terms/
+  title: Apiture Public Events
+  description: Describes the event channels and event messages that the Apiture Open digital banking platform subscribees for client consumption.
   contact:
-    name: API Support
-    url: http://www.asyncapi.org/support
-    email: support@asyncapi.org
+    name: Apiture
+    email: api@apiture.com
+    url: 'https://developer.apiture.com'
   license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-tags:
-  - name: root-tag1
-    externalDocs:
-      description: External docs description 1
-      url: https://www.asyncapi.com/
-  - name: root-tag2
-    description: Description 2
-    externalDocs:
-      url: "https://www.asyncapi.com/"
-  - name: root-tag3
-  - name: root-tag4
-    description: Description 4
-  - name: root-tag5
-    externalDocs:
-      url: "https://www.asyncapi.com/"
-externalDocs:
-  description: Find more info here
-  url: https://example.com
-defaultContentType: application/json
-
+    name: Apiture Open API License Agreement
+    url: 'https://developer.apiture.com/docs/Apiture-Open-API-License-Agreement.pdf'
+  version: 0.2.0
 servers:
-  production:
-    url: api.streetlights.smartylighting.com:{port}
-    protocol: mqtt
-    description: Test broker
-    variables:
-      port:
-        description: Secure connection (TLS) is available through port 8883.
-        default: '1883'
-        enum:
-          - '1883'
-          - '8883'
-    security:
-      - apiKey: []
-      - supportedOauthFlows:
-        - streetlights:on
-        - streetlights:off
-        - streetlights:dim
-      - openIdConnectWellKnown: []
-  dummy-mqtt:
-    url: mqtt://localhost
-    protocol: mqtt
-    description: dummy MQTT broker
-    bindings:
-      mqtt:
-        clientId: guest        
-        cleanSession: false
-        keepAlive: 60
-        bindingVersion: 0.1.0
-        lastWill:
-          topic: smartylighting/streetlights/1/0/lastwill
-          qos: 1
-          message: so long and thanks for all the fish
-          retain: false
-  dummy-amqp:
-    url: amqp://localhost:{port}
-    protocol: amqp
-    description: dummy AMQP broker
-    protocolVersion: "0.9.1"
-    variables:
-      port:
-        enum:
-          - '15672'
-          - '5672'
-  dommy-kafka:
-    url: http://localhost:{port}
-    protocol: kafka
-    description: dummy Kafka broker
-    variables:
-      port:
-        default: '9092'
-
+  sandbox:
+    url: 'https://api.sandbox.apiture.com/async-events'
+    description: The sandbox environment (open/sandbox)
+    protocol: sqs
+tags:
+  - name: Accounts
+    description: Banking Accounts
 channels:
-  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
-    description: The topic on which measured values may be produced and consumed.
-    parameters:
-      streetlightId:
-        $ref: '#/components/parameters/streetlightId'
+  accounts:
+    description: Account related events
     subscribe:
-      summary: Receive information about environmental lighting conditions of a particular streetlight.
-      operationId: receiveLightMeasurement
-      traits:
-        - $ref: '#/components/operationTraits/kafka'
-      message:
-        $ref: '#/components/messages/lightMeasured'
-      bindings:
-        mqtt:
-          qos: 1
-          bindingVersion: 0.1.0
-        http:
-          type: request
-          method: GET
-          query:
-            type: object
-            required:
-            - companyId
-            properties:
-              companyId:
-                type: number
-                minimum: 1
-                description: The Id of the company.
-            additionalProperties: false
-
-  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
-    parameters:
-      streetlightId:
-        $ref: '#/components/parameters/streetlightId'
-    publish:
-      operationId: turnOn
-      traits:
-        - $ref: '#/components/operationTraits/kafka'
-      message:
-        $ref: '#/components/messages/turnOnOff'
-
-  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
-    parameters:
-      streetlightId:
-        $ref: '#/components/parameters/streetlightId'
-    publish:
-      operationId: turnOff
-      traits:
-        - $ref: '#/components/operationTraits/kafka'
-      message:
-        $ref: '#/components/messages/turnOnOff'
-
-  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
-    parameters:
-      streetlightId:
-        $ref: '#/components/parameters/streetlightId'
-    publish:
-      operationId: dimLight
-      traits:
-        - $ref: '#/components/operationTraits/kafka'
-      message:
-        $ref: '#/components/messages/dimLight'
-
-components:
-  messages:
-    lightMeasured:
-      name: lightMeasured
-      title: Light measured
-      summary: Inform about environmental lighting conditions for a particular streetlight.
-      contentType: application/json
-      correlationId:
-        $ref: "#/components/correlationIds/sentAtCorrelator"
-      externalDocs:
-        url: "https://www.asyncapi.com/"
-      traits:
-        - $ref: '#/components/messageTraits/commonHeaders'
-      payload:
-        $ref: "#/components/schemas/lightMeasuredPayload"
-      bindings:
-        mqtt:
-          bindingVersion: 0.1.0
-      examples:
-        - headers:
-            my-app-header: 12
-          payload:
-            lumens: 1
-            sentAt: "2020-01-31T13:24:53Z"
-        - headers:
-            my-app-header: 13
-        - payload:
-            lumens: 3
-            sentAt: "2020-10-31T13:24:53Z"
-      x-schema-extensions-as-object:
-        type: object
-        properties:
-          prop1:
-            type: string
-          prop2:
-            type: integer
-            minimum: 0
-      x-schema-extensions-as-primitive: dummy
-      x-schema-extensions-as-array: 
-        - "item1"
-        - "item2"
-    LwM2mOjbects:
-      payload:
-        type: object
-        properties:
-          objectLinks:
-            type: string
-        example:
-          objectLinks: "lwm2m=1.1, </0/0>, </1/1>;ssid=1, </2>, </3/0>"
-    turnOnOff:
-      name: turnOnOff
-      title: Turn on/off
-      summary: Command a particular streetlight to turn the lights on or off.
-      payload:
-        $ref: "#/components/schemas/turnOnOffPayload"
-      headers: 
-        type: object
-        properties:
-          $ref: '#/components/schemas/streamHeaders'
-    dimLight:
-      name: dimLight
-      title: Dim light
-      summary: Command a particular streetlight to dim the lights.
-      correlationId:
-        $ref: "#/components/correlationIds/sentAtCorrelator"
-      externalDocs:
-        url: "https://www.asyncapi.com/"
+      operationId: accounts
+      summary: Accounts
+      description: Fired after activity on banking accounts
       tags:
-        - name: oparation-tag1
-          externalDocs:
-            description: External docs description 1
-            url: https://www.asyncapi.com/
-        - name: oparation-tag2
-          description: Description 2
-          externalDocs:
-            url: "https://www.asyncapi.com/"
-        - name: oparation-tag3
-        - name: oparation-tag4
-          description: Description 4
-        - name: oparation-tag5
-          externalDocs:
-            url: "https://www.asyncapi.com/"
-      traits:
-        - $ref: '#/components/messageTraits/commonHeaders'
-      payload:
-        $ref: "#/components/schemas/dimLightPayload"
-
+        - name: Accounts
+      message:
+        oneOf:
+          - name: accountCreated
+            payload:
+              $ref: '#/components/schemas/accountCreated'
+            title: Account Created
+            summary: User (Bank Customer) successfully created (opened) an account
+            tags:
+              - name: Accounts
+components:
   schemas:
-    lightMeasuredPayload:
-      type: object
+    accountCreated:
+      title: Account Created
+      description: A banking customer successfully opened a new account.
       properties:
-        lumens:
-          type: integer
-          description: Light intensity measured in lumens.
-          writeOnly: true
-          oneOf: 
-            - minimum: 0
-              maximum: 5
-            - minimum: 10
-              maximum: 20
-          externalDocs:
-            url: "https://www.asyncapi.com/"
-        sentAt:
-          $ref: "#/components/schemas/sentAt"
-        ifElseThen:
-          type: integer
-          minimum: 1
-          maximum: 1000
-          if:
-            minimum: 100
-          then: 
-            multipleOf: 100
-          else:
-            if: 
-              minimum: 10
-            then: 
-              multipleOf: 10
-      required:
-        - lumens
-      x-schema-extensions-as-object:
-        type: object
-        properties:
-          prop1:
-            type: string
-          prop2:
-            type: integer
-            minimum: 0
-      x-schema-extensions-as-primitive: dummy
-      x-schema-extensions-as-array: 
-        - "item1"
-        - "item2"
-    turnOnOffPayload:
-      type: object
-      properties:
-        command:
+        _id:
+          description: The unique ID of this event. This is an opaque string.
           type: string
-          enum:
-            - on
-            - off
-          description: Whether to turn on or off the light.
-        sentAt:
-          $ref: "#/components/schemas/sentAt"
-      additionalProperties:
-        type: string
-
-    dimLightPayload:
-      type: object
-      properties:
-        percentage:
-          type: integer
-          description: Percentage to which the light should be dimmed to.
-          minimum: 0
-          maximum: 100
-          readOnly: true
-        sentAt:
-          $ref: "#/components/schemas/sentAt"
-        key:
-          type: integer
-          not:
-            minimum: 3
-      patternProperties:
-        ^S_:
+          maxLength: 48
+        occurredAt:
+          description: 'The [RFC 3339](https://tools.ietf.org/html/rfc3339) date-time (UTC) when the event occurred.'
           type: string
-        ^I_:
-          type: integer
-      additionalProperties: false
-    sentAt:
-      type: string
-      format: date-time
-      description: Date and time when the message was sent.
-    union:
-      type: [string, number]
-    objectWithKey:
-      type: object
-      propertyNames:
-        format: email
-      properties:
-        key:
-          type: string
-    objectWithKey2:
-      type: object
-      properties:
-        key2:
-          type: string
-    oneOfSchema:
-      oneOf:
-        - $ref: "#/components/schemas/objectWithKey"
-        - $ref: "#/components/schemas/objectWithKey2"
-    anyOfSchema:
-      anyOf:
-        - $ref: "#/components/schemas/objectWithKey"
-        - $ref: "#/components/schemas/objectWithKey2"
-    allOfSchema:
-      allOf:
-        - $ref: "#/components/schemas/objectWithKey"
-        - $ref: "#/components/schemas/objectWithKey2"
-    arrayContains: 
-      type: array
-      contains:
-        type: integer
-
-    subscriptionStatus:
-      type: object
-      oneOf:
-        - properties:
-            channelID:
-              type: integer
-              description: ChannelID on successful subscription, applicable to public messages only.
-            channelName:
-              type: string
-              description: Channel Name on successful subscription. For payloads 'ohlc' and 'book', respective interval or depth will be added as suffix.
-        - properties:
-            errorMessage:
-              type: string
-      properties:
-        event:
-          type: string
-          const: subscriptionStatus
-        subscription:
-          type: object
-          properties:
-            depth:
-              type: string
-            interval:
-              type: string
-          required:
-            - name
-      required:
-        - event
-
-    streamHeaders:
-      Etag:
-        type: string
-        description: |
-          The RFC7232 ETag header field in a response provides the current entity-
-          tag for the selected resource. An entity-tag is an opaque identifier for
-          different versions of a resource over time, regardless whether multiple
-          versions are valid at the same time. An entity-tag consists of an opaque
-          quoted string, possibly prefixed by a weakness indicator.
-        example: 411a
-      Cache-Control:
-        description: The Cache-Control HTTP header holds directives (instructions) for caching in request.
-        type: string
-        example: no-cache, no-store, must-revalidate
-
-  securitySchemes:
-    apiKey:
-      type: apiKey
-      in: user
-      description: Provide your API key as the user and leave the password empty.
-    supportedOauthFlows:
-      type: oauth2
-      description: Flows to support OAuth 2.0
-      flows:
-        implicit:
-          authorizationUrl: 'https://authserver.example/auth'
-          scopes:
-            'streetlights:on': Ability to switch lights on
-            'streetlights:off': Ability to switch lights off
-            'streetlights:dim': Ability to dim the lights
-        password:
-          tokenUrl: 'https://authserver.example/token'
-          scopes:
-            'streetlights:on': Ability to switch lights on
-            'streetlights:off': Ability to switch lights off
-            'streetlights:dim': Ability to dim the lights
-        clientCredentials:
-          tokenUrl: 'https://authserver.example/token'
-          scopes:
-            'streetlights:on': Ability to switch lights on
-            'streetlights:off': Ability to switch lights off
-            'streetlights:dim': Ability to dim the lights
-        authorizationCode:
-          authorizationUrl: 'https://authserver.example/auth'
-          tokenUrl: 'https://authserver.example/token'
-          refreshUrl: 'https://authserver.example/refresh'
-          scopes:
-            'streetlights:on': Ability to switch lights on
-            'streetlights:off': Ability to switch lights off
-            'streetlights:dim': Ability to dim the lights
-    openIdConnectWellKnown:
-      type: openIdConnect
-      openIdConnectUrl: 'https://authserver.example/.well-known'
-
-  parameters:
-    streetlightId:
-      description: The ID of the streetlight.
-      schema:
-        type: string
-      location: "$message.payload#/user/id"
-
-  correlationIds:
-    sentAtCorrelator:
-      description: Data from message payload used as correlation ID
-      location: $message.payload#/sentAt
-
-  messageTraits:
-    commonHeaders:
-      headers:
-        type: object
-        properties:
-          my-app-header:
-            type: integer
-            minimum: 0
-            maximum: 100
-        required:
-          - my-app-header
-  
-  operationTraits:
-    kafka:
-      bindings:
-        kafka:
-          clientId: my-app-id
+          format: date-time
+      example:
+        _id: event1234
+        occurredAt: '2021-05-05T13:21:39.375Z'
 `;

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -1,58 +1,473 @@
 export const streetlights = `
-asyncapi: 2.0.0
-id: 'https://api.apiture.com/apis/async-api-id/apiture-public-events'
+asyncapi: '2.0.0'
+id: 'urn:com:smartylighting:streetlights:server'
 info:
-  title: Apiture Public Events
-  description: Describes the event channels and event messages that the Apiture Open digital banking platform subscribees for client consumption.
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+
+  termsOfService: http://asyncapi.org/terms/
   contact:
-    name: Apiture
-    email: api@apiture.com
-    url: 'https://developer.apiture.com'
+    name: API Support
+    url: http://www.asyncapi.org/support
+    email: support@asyncapi.org
   license:
-    name: Apiture Open API License Agreement
-    url: 'https://developer.apiture.com/docs/Apiture-Open-API-License-Agreement.pdf'
-  version: 0.2.0
-servers:
-  sandbox:
-    url: 'https://api.sandbox.apiture.com/async-events'
-    description: The sandbox environment (open/sandbox)
-    protocol: sqs
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
-  - name: Accounts
-    description: Banking Accounts
+  - name: root-tag1
+    externalDocs:
+      description: External docs description 1
+      url: https://www.asyncapi.com/
+  - name: root-tag2
+    description: Description 2
+    externalDocs:
+      url: "https://www.asyncapi.com/"
+  - name: root-tag3
+  - name: root-tag4
+    description: Description 4
+  - name: root-tag5
+    externalDocs:
+      url: "https://www.asyncapi.com/"
+externalDocs:
+  description: Find more info here
+  url: https://example.com
+defaultContentType: application/json
+
+servers:
+  production:
+    url: api.streetlights.smartylighting.com:{port}
+    protocol: mqtt
+    description: Test broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+    security:
+      - apiKey: []
+      - supportedOauthFlows:
+        - streetlights:on
+        - streetlights:off
+        - streetlights:dim
+      - openIdConnectWellKnown: []
+  dummy-mqtt:
+    url: mqtt://localhost
+    protocol: mqtt
+    description: dummy MQTT broker
+    bindings:
+      mqtt:
+        clientId: guest        
+        cleanSession: false
+        keepAlive: 60
+        bindingVersion: 0.1.0
+        lastWill:
+          topic: smartylighting/streetlights/1/0/lastwill
+          qos: 1
+          message: so long and thanks for all the fish
+          retain: false
+  dummy-amqp:
+    url: amqp://localhost:{port}
+    protocol: amqp
+    description: dummy AMQP broker
+    protocolVersion: "0.9.1"
+    variables:
+      port:
+        enum:
+          - '15672'
+          - '5672'
+  dommy-kafka:
+    url: http://localhost:{port}
+    protocol: kafka
+    description: dummy Kafka broker
+    variables:
+      port:
+        default: '9092'
+
 channels:
-  accounts:
-    description: Account related events
+  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     subscribe:
-      operationId: accounts
-      summary: Accounts
-      description: Fired after activity on banking accounts
-      tags:
-        - name: Accounts
+      summary: Receive information about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
       message:
-        oneOf:
-          - name: accountCreated
-            payload:
-              $ref: '#/components/schemas/accountCreated'
-            title: Account Created
-            summary: User (Bank Customer) successfully created (opened) an account
-            tags:
-              - name: Accounts
+        $ref: '#/components/messages/lightMeasured'
+      bindings:
+        mqtt:
+          qos: 1
+          bindingVersion: 0.1.0
+        http:
+          type: request
+          method: GET
+          query:
+            type: object
+            required:
+            - companyId
+            properties:
+              companyId:
+                type: number
+                minimum: 1
+                description: The Id of the company.
+            additionalProperties: false
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+
 components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions for a particular streetlight.
+      contentType: application/json
+      correlationId:
+        $ref: "#/components/correlationIds/sentAtCorrelator"
+      externalDocs:
+        url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+      bindings:
+        mqtt:
+          bindingVersion: 0.1.0
+      examples:
+        - headers:
+            my-app-header: 12
+          payload:
+            lumens: 1
+            sentAt: "2020-01-31T13:24:53Z"
+        - headers:
+            my-app-header: 13
+        - payload:
+            lumens: 3
+            sentAt: "2020-10-31T13:24:53Z"
+      x-schema-extensions-as-object:
+        type: object
+        properties:
+          prop1:
+            type: string
+          prop2:
+            type: integer
+            minimum: 0
+      x-schema-extensions-as-primitive: dummy
+      x-schema-extensions-as-array: 
+        - "item1"
+        - "item2"
+    LwM2mOjbects:
+      payload:
+        type: object
+        properties:
+          objectLinks:
+            type: string
+        example:
+          objectLinks: "lwm2m=1.1, </0/0>, </1/1>;ssid=1, </2>, </3/0>"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+      headers: 
+        type: object
+        properties:
+          $ref: '#/components/schemas/streamHeaders'
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      correlationId:
+        $ref: "#/components/correlationIds/sentAtCorrelator"
+      externalDocs:
+        url: "https://www.asyncapi.com/"
+      tags:
+        - name: oparation-tag1
+          externalDocs:
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: oparation-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: oparation-tag3
+        - name: oparation-tag4
+          description: Description 4
+        - name: oparation-tag5
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
   schemas:
-    accountCreated:
-      title: Account Created
-      description: A banking customer successfully opened a new account.
+    lightMeasuredPayload:
+      type: object
       properties:
-        _id:
-          description: The unique ID of this event. This is an opaque string.
+        lumens:
+          type: integer
+          description: Light intensity measured in lumens.
+          writeOnly: true
+          oneOf: 
+            - minimum: 0
+              maximum: 5
+            - minimum: 10
+              maximum: 20
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+        ifElseThen:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          if:
+            minimum: 100
+          then: 
+            multipleOf: 100
+          else:
+            if: 
+              minimum: 10
+            then: 
+              multipleOf: 10
+      required:
+        - lumens
+      x-schema-extensions-as-object:
+        type: object
+        properties:
+          prop1:
+            type: string
+          prop2:
+            type: integer
+            minimum: 0
+      x-schema-extensions-as-primitive: dummy
+      x-schema-extensions-as-array: 
+        - "item1"
+        - "item2"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
           type: string
-          maxLength: 48
-        occurredAt:
-          description: 'The [RFC 3339](https://tools.ietf.org/html/rfc3339) date-time (UTC) when the event occurred.'
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+      additionalProperties:
+        type: string
+
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+          readOnly: true
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+        key:
+          type: integer
+          not:
+            minimum: 3
+      patternProperties:
+        ^S_:
           type: string
-          format: date-time
-      example:
-        _id: event1234
-        occurredAt: '2021-05-05T13:21:39.375Z'
+        ^I_:
+          type: integer
+      additionalProperties: false
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+    union:
+      type: [string, number]
+    objectWithKey:
+      type: object
+      propertyNames:
+        format: email
+      properties:
+        key:
+          type: string
+    objectWithKey2:
+      type: object
+      properties:
+        key2:
+          type: string
+    oneOfSchema:
+      oneOf:
+        - $ref: "#/components/schemas/objectWithKey"
+        - $ref: "#/components/schemas/objectWithKey2"
+    anyOfSchema:
+      anyOf:
+        - $ref: "#/components/schemas/objectWithKey"
+        - $ref: "#/components/schemas/objectWithKey2"
+    allOfSchema:
+      allOf:
+        - $ref: "#/components/schemas/objectWithKey"
+        - $ref: "#/components/schemas/objectWithKey2"
+    arrayContains: 
+      type: array
+      contains:
+        type: integer
+
+    subscriptionStatus:
+      type: object
+      oneOf:
+        - properties:
+            channelID:
+              type: integer
+              description: ChannelID on successful subscription, applicable to public messages only.
+            channelName:
+              type: string
+              description: Channel Name on successful subscription. For payloads 'ohlc' and 'book', respective interval or depth will be added as suffix.
+        - properties:
+            errorMessage:
+              type: string
+      properties:
+        event:
+          type: string
+          const: subscriptionStatus
+        subscription:
+          type: object
+          properties:
+            depth:
+              type: string
+            interval:
+              type: string
+          required:
+            - name
+      required:
+        - event
+
+    streamHeaders:
+      Etag:
+        type: string
+        description: |
+          The RFC7232 ETag header field in a response provides the current entity-
+          tag for the selected resource. An entity-tag is an opaque identifier for
+          different versions of a resource over time, regardless whether multiple
+          versions are valid at the same time. An entity-tag consists of an opaque
+          quoted string, possibly prefixed by a weakness indicator.
+        example: 411a
+      Cache-Control:
+        description: The Cache-Control HTTP header holds directives (instructions) for caching in request.
+        type: string
+        example: no-cache, no-store, must-revalidate
+
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: user
+      description: Provide your API key as the user and leave the password empty.
+    supportedOauthFlows:
+      type: oauth2
+      description: Flows to support OAuth 2.0
+      flows:
+        implicit:
+          authorizationUrl: 'https://authserver.example/auth'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        password:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/auth'
+          tokenUrl: 'https://authserver.example/token'
+          refreshUrl: 'https://authserver.example/refresh'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+    openIdConnectWellKnown:
+      type: openIdConnect
+      openIdConnectUrl: 'https://authserver.example/.well-known'
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+      location: "$message.payload#/user/id"
+
+  correlationIds:
+    sentAtCorrelator:
+      description: Data from message payload used as correlation ID
+      location: $message.payload#/sentAt
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+        required:
+          - my-app-header
+  
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id
 `;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Check if given part of spec exists, if not, then don't return this part (changed parts are required to define in spec, but check it to be sure).
- Render first index of `oneOf` messages... `hasMultipleMessages` has broken meaning... 🤦🏼 

**Related issue(s)**
See also https://github.com/asyncapi/html-template/issues/191
