### PR TITLE
feat: render missed parts for operations and render spec id

### DIFF
--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -231,7 +231,7 @@ export const Schema: React.FunctionComponent<Props> = ({
 
         {isCircular || !isExpandable ? null : (
           <div
-            className={`rounded p-4 py-2 bg-gray-100 ${
+            className={`rounded p-4 py-2 bg-gray-100 border bg-gray-100 ${
               reverse ? 'bg-gray-200' : ''
             } ${expand ? 'block' : 'hidden'}`}
           >

--- a/library/src/containers/Info/Info.tsx
+++ b/library/src/containers/Info/Info.tsx
@@ -18,6 +18,7 @@ export const Info: React.FunctionComponent = () => {
     return null;
   }
 
+  const specId = asyncapi.id();
   const externalDocs = asyncapi.externalDocs();
   const license = info.license();
   const termsOfService = info.termsOfService();
@@ -105,6 +106,13 @@ export const Info: React.FunctionComponent = () => {
                   </li>
                 )}
               </>
+            )}
+            {specId && (
+              <li className="inline-block mt-2 mr-2">
+                <span className="border border-solid border-blue-300 hover:bg-blue-300 hover:text-blue-600 text-blue-500 font-bold no-underline text-xs uppercase rounded px-3 py-1">
+                  ID: {specId}
+                </span>
+              </li>
             )}
           </ul>
         )}

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -44,7 +44,7 @@ export const Message: React.FunctionComponent<Props> = ({
   return (
     <div className="panel-item">
       <div className="panel-item--center px-8">
-        <div className="shadow rounded bg-gray-200 p-4">
+        <div className="shadow rounded bg-gray-200 p-4 border bg-gray-100">
           <div>
             {index !== undefined && (
               <span className="text-gray-700 font-bold mr-2">#{index}</span>

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import { Channel, Operation as OperationType } from '@asyncapi/parser';
 
 import { Message } from '../Messages/Message';
-import { Markdown, Schema, Bindings, Tags, Extensions } from '../../components';
+import {
+  Href,
+  Markdown,
+  Schema,
+  Bindings,
+  Tags,
+  Extensions,
+} from '../../components';
 
 import { SchemaHelpers } from '../../helpers';
+import { EXTERAL_DOCUMENTATION_TEXT } from '../../constants';
 import { PayloadType } from '../../types';
 
 interface Props {
@@ -23,6 +31,9 @@ export const Operation: React.FunctionComponent<Props> = ({
   if (!operation) {
     return null;
   }
+
+  const operationId = operation.id();
+  const externalDocs = operation.externalDocs();
 
   const parameters = SchemaHelpers.parametersToSchema(channel.parameters());
   const operationSummary = operation.summary();
@@ -57,6 +68,32 @@ export const Operation: React.FunctionComponent<Props> = ({
         {operation.hasDescription() && (
           <div className="mt-2">
             <Markdown>{operation.description()}</Markdown>
+          </div>
+        )}
+
+        {externalDocs && (
+          <ul className="leading-normal mt-2 mb-4 space-x-2 space-y-2">
+            {externalDocs && (
+              <li className="inline-block">
+                <Href
+                  className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                  href={externalDocs.url()}
+                >
+                  <span>{EXTERAL_DOCUMENTATION_TEXT}</span>
+                </Href>
+              </li>
+            )}
+          </ul>
+        )}
+
+        {operationId && (
+          <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
+            <div className="text-sm text-gray-700">
+              Operation ID
+              <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                {operationId}
+              </span>
+            </div>
           </div>
         )}
 

--- a/library/src/containers/Servers/Server.tsx
+++ b/library/src/containers/Servers/Server.tsx
@@ -28,7 +28,7 @@ export const Server: React.FunctionComponent<Props> = ({
   return (
     <div className="panel-item">
       <div className="panel-item--center px-8">
-        <div className="shadow rounded bg-gray-200 p-4">
+        <div className="shadow rounded bg-gray-200 p-4 border bg-gray-100">
           <div>
             <span className="font-mono text-base">{server.url()}</span>
             <span className="bg-teal-500 font-bold no-underline text-white uppercase rounded mx-2 px-2 py-1 text-sm">

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -102,6 +102,9 @@ channels:
     subscribe:
       summary: Receive information about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
       traits:
         - $ref: '#/components/operationTraits/kafka'
       message:
@@ -130,6 +133,9 @@ channels:
         $ref: '#/components/parameters/streetlightId'
     publish:
       operationId: turnOn
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
       traits:
         - $ref: '#/components/operationTraits/kafka'
       message:
@@ -140,7 +146,6 @@ channels:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
     publish:
-      operationId: turnOff
       traits:
         - $ref: '#/components/operationTraits/kafka'
       message:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Render missed parts for operation:
- `operationId`
- `externalDocs`

Render `id` of spec.

ID:
![image](https://user-images.githubusercontent.com/20404945/118638809-83156080-b7d7-11eb-87b5-c156813cb21b.png)

Operation:
![image](https://user-images.githubusercontent.com/20404945/118638848-8c9ec880-b7d7-11eb-9e84-99314e8299f4.png)

**Related issue(s)**
Part of https://github.com/asyncapi/asyncapi-react/issues/63
