### PR TITLE
feat: update openapi-sampler to 1.0.0 for better examples generation

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -612,6 +612,11 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+    },
     "@types/linkify-it": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-2.1.0.tgz",
@@ -3454,11 +3459,12 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.16.tgz",
-      "integrity": "sha512-05+GvwMagTY7GxoDQoWJfmAUFlxfebciiEzqKmu4iq6+MqBEn62AMUkn0CTxyKhnUGIaR2KXjTeslxIeJwVIOw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0.tgz",
+      "integrity": "sha512-HysKj4ZuLk0RpZkopao5SIupUX8LMOTsEDTw9dSzcRv6BBW6Ep1IdbKwYsCrYM9tnw4VZtebR/N5sJHY6qqRew==",
       "requires": {
-        "json-pointer": "^0.6.0"
+        "@types/json-schema": "^7.0.7",
+        "json-pointer": "^0.6.1"
       }
     },
     "optionator": {

--- a/library/package.json
+++ b/library/package.json
@@ -53,7 +53,7 @@
     "dompurify": "^2.1.1",
     "markdown-it": "^11.0.1",
     "merge": "^2.1.0",
-    "openapi-sampler": "^1.0.0-beta.15",
+    "openapi-sampler": "1.0.0",
     "react-use": "^12.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes proposed in this pull request:

Update `openapi-sampler` package to `1.0.0`. Support for more type formats and JSON Schema 7 driven by support for OpenAPI 3.1.
Changes: https://github.com/Redocly/openapi-sampler/pull/122

**Related issue(s)**
Fixes https://github.com/asyncapi/asyncapi-react/issues/209