### PR TITLE
feat: add prefix for css classes

### DIFF
--- a/library/src/components/CollapseButton.tsx
+++ b/library/src/components/CollapseButton.tsx
@@ -9,7 +9,7 @@ export const CollapseButton: React.FunctionComponent<Props> = ({
   children,
   ...rest
 }) => (
-  <button {...rest} className={`focus:outline-none ${rest.className}`}>
+  <button {...rest} className={`focus:aui-outline-none ${rest.className}`}>
     {children}
     <svg
       version="1.1"
@@ -18,7 +18,7 @@ export const CollapseButton: React.FunctionComponent<Props> = ({
       xmlns="http://www.w3.org/2000/svg"
       y="0"
       {...chevronProps}
-      className={`inline-block align-baseline cursor-pointer -mb-1 w-5 transform transition-transform duration-150 ease-linear ${chevronProps?.className ||
+      className={`aui-inline-block aui-align-baseline aui-cursor-pointer aui--mb-1 aui-w-5 aui-transform aui-transition-transform aui-duration-150 aui-ease-linear ${chevronProps?.className ||
         ''}`}
     >
       <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 " />

--- a/library/src/components/Extensions.tsx
+++ b/library/src/components/Extensions.tsx
@@ -20,7 +20,7 @@ export const Extensions: React.FunctionComponent<Props> = ({
 
   const schema = SchemaHelpers.jsonToSchema(extensions);
   return (
-    <div className="mt-2">
+    <div className="aui-mt-2">
       <Schema schemaName={name} schema={schema} />
     </div>
   );

--- a/library/src/components/Markdown.tsx
+++ b/library/src/components/Markdown.tsx
@@ -13,7 +13,7 @@ export const Markdown: React.FunctionComponent = ({ children }) => {
 
   return (
     <div
-      className="prose max-w-full text-sm"
+      className="aui-prose aui-max-w-full aui-text-sm"
       dangerouslySetInnerHTML={{ __html: sanitize(renderMarkdown(children)) }}
     />
   );

--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -70,18 +70,18 @@ export const Schema: React.FunctionComponent<Props> = ({
   return (
     <SchemaContext.Provider value={{ reverse: !reverse }}>
       <div>
-        <div className="flex py-2">
-          <div className="w-3/12 min-w-min mr-2">
+        <div className="aui-flex aui-py-2">
+          <div className="aui-w-3/12 aui-min-w-min aui-mr-2">
             {isExpandable && !isCircular ? (
               <CollapseButton
                 onClick={() => setExpand(prev => !prev)}
                 chevronProps={{
-                  className: expand ? '-rotate-180' : '-rotate-90',
+                  className: expand ? 'aui--rotate-180' : 'aui--rotate-90',
                 }}
               >
                 <span
-                  className={`break-words text-sm ${
-                    isProperty ? 'italic' : ''
+                  className={`aui-break-words aui-text-sm ${
+                    isProperty ? 'aui-italic' : ''
                   }`}
                 >
                   {schemaName}
@@ -89,71 +89,75 @@ export const Schema: React.FunctionComponent<Props> = ({
               </CollapseButton>
             ) : (
               <span
-                className={`break-words text-sm ${isProperty ? 'italic' : ''}`}
+                className={`aui-break-words aui-text-sm ${
+                  isProperty ? 'aui-italic' : ''
+                }`}
               >
                 {schemaName}
               </span>
             )}
             {isPatternProperty && (
-              <div className="text-gray-500 text-xs italic">
+              <div className="aui-text-gray-500 aui-text-xs aui-italic">
                 (pattern property)
               </div>
             )}
-            {required && <div className="text-red-600 text-xs">required</div>}
+            {required && (
+              <div className="aui-text-red-600 aui-text-xs">required</div>
+            )}
             {dependentRequired && (
               <>
-                <div className="text-gray-500 text-xs">
+                <div className="aui-text-gray-500 aui-text-xs">
                   required when defined:
                 </div>
-                <div className="text-red-600 text-xs">
+                <div className="aui-text-red-600 aui-text-xs">
                   {dependentRequired.join(', ')}
                 </div>
               </>
             )}
             {schema.deprecated() && (
-              <div className="text-red-600 text-xs">deprecated</div>
+              <div className="aui-text-red-600 aui-text-xs">deprecated</div>
             )}
             {schema.writeOnly() && (
-              <div className="text-gray-500 text-xs">write-only</div>
+              <div className="aui-text-gray-500 aui-text-xs">write-only</div>
             )}
             {schema.readOnly() && (
-              <div className="text-gray-500 text-xs">read-only</div>
+              <div className="aui-text-gray-500 aui-text-xs">read-only</div>
             )}
           </div>
           {rawValue ? (
             <div>
-              <div className="text-sm">{schema.const()}</div>
+              <div className="aui-text-sm">{schema.const()}</div>
             </div>
           ) : (
             <div>
               <div>
                 {renderType && (
-                  <div className="capitalize text-sm text-teal-500 font-bold inline-block mr-2">
+                  <div className="aui-capitalize aui-text-sm aui-text-teal-500 aui-font-bold aui-inline-block aui-mr-2">
                     {isCircular
                       ? `${SchemaHelpers.toSchemaType(schema)} [CIRCULAR]`
                       : SchemaHelpers.toSchemaType(schema)}
                   </div>
                 )}
-                <div className="inline-block">
+                <div className="aui-inline-block">
                   {schema.format() && (
-                    <span className="bg-yellow-600 font-bold no-underline text-white rounded lowercase mr-2 p-1 text-xs">
+                    <span className="aui-bg-yellow-600 aui-font-bold aui-no-underline aui-text-white aui-rounded aui-lowercase aui-mr-2 aui-p-1 aui-text-xs">
                       format: {schema.format()}
                     </span>
                   )}
 
                   {/* related to string */}
                   {schema.pattern() !== undefined && (
-                    <span className="bg-yellow-600 font-bold no-underline text-white rounded lowercase mr-2 p-1 text-xs">
+                    <span className="aui-bg-yellow-600 aui-font-bold aui-no-underline aui-text-white aui-rounded aui-lowercase aui-mr-2 aui-p-1 aui-text-xs">
                       must match: {schema.pattern()}
                     </span>
                   )}
                   {schema.contentMediaType() !== undefined && (
-                    <span className="bg-yellow-600 font-bold no-underline text-white rounded lowercase mr-2 p-1 text-xs">
+                    <span className="aui-bg-yellow-600 aui-font-bold aui-no-underline aui-text-white aui-rounded aui-lowercase aui-mr-2 aui-p-1 aui-text-xs">
                       media type: {schema.contentMediaType()}
                     </span>
                   )}
                   {schema.contentEncoding() !== undefined && (
-                    <span className="bg-yellow-600 font-bold no-underline text-white rounded lowercase mr-2 p-1 text-xs">
+                    <span className="aui-bg-yellow-600 aui-font-bold aui-no-underline aui-text-white aui-rounded aui-lowercase aui-mr-2 aui-p-1 aui-text-xs">
                       encoding: {schema.contentEncoding()}
                     </span>
                   )}
@@ -162,7 +166,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                   {!!constraints.length &&
                     constraints.map(c => (
                       <span
-                        className="bg-purple-600 font-bold no-underline text-white rounded lowercase mr-2 p-1 text-xs"
+                        className="aui-bg-purple-600 aui-font-bold aui-no-underline aui-text-white aui-rounded aui-lowercase aui-mr-2 aui-p-1 aui-text-xs"
                         key={c}
                       >
                         {c}
@@ -170,7 +174,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                     ))}
 
                   {uid && !uid.startsWith('<anonymous-') && (
-                    <span className="border text-orange-600 rounded mr-2 p-1 text-xs">
+                    <span className="aui-border aui-text-orange-600 aui-rounded aui-mr-2 aui-p-1 aui-text-xs">
                       uid: {uid}
                     </span>
                   )}
@@ -183,28 +187,28 @@ export const Schema: React.FunctionComponent<Props> = ({
                 )}
 
                 {schema.default() !== undefined && (
-                  <div className="text-xs">
+                  <div className="aui-text-xs">
                     Default value:
-                    <span className="border inline-block text-orange-600 rounded ml-1 py-0 px-2">
+                    <span className="aui-border aui-inline-block aui-text-orange-600 aui-rounded aui-ml-1 aui-py-0 aui-px-2">
                       {SchemaHelpers.prettifyValue(schema.default())}
                     </span>
                   </div>
                 )}
                 {schema.const() !== undefined && (
-                  <div className="text-xs">
+                  <div className="aui-text-xs">
                     Const:
-                    <span className="border inline-block text-orange-600 rounded ml-1 py-0 px-2">
+                    <span className="aui-border aui-inline-block aui-text-orange-600 aui-rounded aui-ml-1 aui-py-0 aui-px-2">
                       {SchemaHelpers.prettifyValue(schema.const())}
                     </span>
                   </div>
                 )}
                 {schema.enum() && (
-                  <ul className="text-xs">
+                  <ul className="aui-text-xs">
                     Allowed values:{' '}
                     {schema.enum().map((e, idx) => (
                       <li
                         key={idx}
-                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2"
+                        className="aui-border aui-inline-block aui-text-orange-600 aui-rounded aui-ml-1 aui-py-0 aui-px-2"
                       >
                         <span>{SchemaHelpers.prettifyValue(e)}</span>
                       </li>
@@ -212,15 +216,15 @@ export const Schema: React.FunctionComponent<Props> = ({
                   </ul>
                 )}
                 {parameterLocation && (
-                  <div className="text-xs">
+                  <div className="aui-text-xs">
                     Parameter location:{' '}
-                    <span className="border text-orange-600 rounded mr-2 p-1 text-xs">
+                    <span className="aui-border aui-text-orange-600 aui-rounded aui-mr-2 aui-p-1 aui-text-xs">
                       {parameterLocation}
                     </span>
                   </div>
                 )}
                 {externalDocs && (
-                  <span className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-2 py-0">
+                  <span className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-2 aui-py-0">
                     <Href
                       href={externalDocs.url()}
                       title={externalDocs.description() || ''}
@@ -230,12 +234,12 @@ export const Schema: React.FunctionComponent<Props> = ({
                   </span>
                 )}
                 {schema.examples() && (
-                  <ul className="text-xs">
+                  <ul className="aui-text-xs">
                     Examples values:{' '}
                     {schema.examples().map((e, idx) => (
                       <li
                         key={idx}
-                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2"
+                        className="aui-border aui-inline-block aui-text-orange-600 aui-rounded aui-ml-1 aui-py-0 aui-px-2"
                       >
                         <span>{SchemaHelpers.prettifyValue(e)}</span>
                       </li>
@@ -249,9 +253,9 @@ export const Schema: React.FunctionComponent<Props> = ({
 
         {isCircular || !isExpandable ? null : (
           <div
-            className={`rounded p-4 py-2 bg-gray-100 border bg-gray-100 ${
-              reverse ? 'bg-gray-200' : ''
-            } ${expand ? 'block' : 'hidden'}`}
+            className={`aui-rounded aui-p-4 aui-py-2 aui-bg-gray-100 aui-border aui-bg-gray-100 ${
+              reverse ? 'aui-bg-gray-200' : ''
+            } ${expand ? 'aui-block' : 'aui-hidden'}`}
           >
             <SchemaProperties schema={schema} />
             <SchemaItems schema={schema} />
@@ -400,14 +404,14 @@ const AdditionalProperties: React.FunctionComponent<AdditionalPropertiesProps> =
   const additionalProperties = schema.additionalProperties();
   if (additionalProperties === true || additionalProperties === undefined) {
     return (
-      <p className="mt-2 text-xs text-gray-700">
+      <p className="aui-mt-2 aui-text-xs aui-text-gray-700">
         Additional properties are allowed.
       </p>
     );
   }
   if (additionalProperties === false) {
     return (
-      <p className="mt-2 text-xs text-gray-700">
+      <p className="aui-mt-2 aui-text-xs aui-text-gray-700">
         Additional properties are <strong>NOT</strong> allowed.
       </p>
     );
@@ -471,14 +475,14 @@ const AdditionalItems: React.FunctionComponent<AdditionalItemsProps> = ({
   const additionalItems = schema.additionalItems() as any;
   if (additionalItems === true || additionalItems === undefined) {
     return (
-      <p className="mt-2 text-xs text-gray-700">
+      <p className="aui-mt-2 aui-text-xs aui-text-gray-700">
         Additional items are allowed.
       </p>
     );
   }
   if (additionalItems === false) {
     return (
-      <p className="mt-2 text-xs text-gray-700">
+      <p className="aui-mt-2 aui-text-xs aui-text-gray-700">
         Additional items are <strong>NOT</strong> allowed.
       </p>
     );

--- a/library/src/components/Tag.tsx
+++ b/library/src/components/Tag.tsx
@@ -15,7 +15,7 @@ export const Tag: React.FunctionComponent<Props> = ({ tag }) => {
   const element = (
     <div
       title={description}
-      className="border border-solid border-blue-300 hover:bg-blue-300 hover:text-blue-600 text-blue-500 font-bold no-underline text-xs rounded px-3 py-1"
+      className="aui-border aui-border-solid aui-border-blue-300 hover:aui-bg-blue-300 hover:aui-text-blue-600 aui-text-blue-500 aui-font-bold aui-no-underline aui-text-xs aui-rounded aui-px-3 aui-py-1"
     >
       <span className={externalDocs ? 'underline' : ''}>{name}</span>
     </div>

--- a/library/src/components/Tags.tsx
+++ b/library/src/components/Tags.tsx
@@ -13,9 +13,9 @@ export const Tags: React.FunctionComponent<Props> = ({ tags }) => {
   }
 
   return (
-    <ul className="flex flex-wrap leading-normal">
+    <ul className="aui-flex aui-flex-wrap aui-leading-normal">
       {tags.map(tag => (
-        <li className="inline-block mt-2 mr-2" key={tag.name()}>
+        <li className="aui-inline-block aui-mt-2 aui-mr-2" key={tag.name()}>
           <Tag tag={tag} />
         </li>
       ))}

--- a/library/src/containers/AsyncApi/Layout.tsx
+++ b/library/src/containers/AsyncApi/Layout.tsx
@@ -41,20 +41,20 @@ const AsyncApiLayout: React.FunctionComponent<Props> = ({
       <section
         className={`${
           divWidth <= 1280 ? 'container:xl' : 'container:base'
-        } relative md:flex bg-white`}
+        } aui-relative md:aui-flex aui-bg-white`}
         id={bemClasses.getSchemaID()}
         ref={ref}
       >
         {config.show?.sidebar && <Sidebar config={config.sidebar} />}
-        <div className="panel--center relative py-8 flex-1">
-          <div className="relative z-10">
+        <div className="panel--center aui-relative aui-py-8 aui-flex-1">
+          <div className="aui-relative aui-z-10">
             {config.show?.errors && error && <Error error={error} />}
             {config.show?.info && <Info />}
             {config.show?.servers && <Servers />}
             {config.show?.operations && <Operations />}
             {config.show?.messages && <Messages />}
           </div>
-          <div className="panel--right absolute top-0 right-0 h-full bg-gray-800" />
+          <div className="panel--right aui-absolute aui-top-0 aui-right-0 aui-h-full aui-bg-gray-800" />
         </div>
       </section>
     </SpecificationContext.Provider>

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -14,9 +14,9 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
         return null;
       }
       return (
-        <div key={index} className="flex">
+        <div key={index} className="aui-flex">
           <span>{`${singleError.location.startLine}.`}</span>
-          <code className="whitespace-pre-wrap break-all ml-2">
+          <code className="aui-whitespace-pre-wrap aui-break-all aui-ml-2">
             {singleError.title}
           </code>
         </div>
@@ -37,13 +37,13 @@ export const Error: React.FunctionComponent<Props> = ({ error }) => {
 
   return (
     <div className="panel-item">
-      <div className="panel-item--center p-8">
-        <section className="shadow rounded bg-gray-200 border-red-500 border-l-8">
-          <h2 className="p-2">
+      <div className="panel-item--center aui-p-8">
+        <section className="aui-shadow aui-rounded aui-bg-gray-200 aui-border-red-500 aui-border-l-8">
+          <h2 className="aui-p-2">
             {title ? `${ERROR_TEXT}: ${title}` : ERROR_TEXT}
           </h2>
           {validationErrors && validationErrors.length ? (
-            <div className="bg-gray-800 text-white text-xs p-2">
+            <div className="aui-bg-gray-800 aui-text-white aui-text-xs aui-p-2">
               <pre>{renderErrors(validationErrors)}</pre>
             </div>
           ) : null}

--- a/library/src/containers/Info/Info.tsx
+++ b/library/src/containers/Info/Info.tsx
@@ -30,33 +30,36 @@ export const Info: React.FunctionComponent = () => {
 
   return (
     <div className="panel-item">
-      <div className="panel-item--center px-8 text-left" id="introduction">
-        <div className="text-4xl">
+      <div
+        className="panel-item--center aui-px-8 aui-text-left"
+        id="introduction"
+      >
+        <div className="aui-text-4xl">
           {info.title()}&nbsp;{info.version()}
         </div>
 
         {showInfoList && (
-          <ul className="flex flex-wrap mt-2 leading-normal">
+          <ul className="aui-flex aui-flex-wrap aui-mt-2 aui-leading-normal">
             {license && (
-              <li className="inline-block mt-2 mr-2">
+              <li className="aui-inline-block aui-mt-2 aui-mr-2">
                 {license.url() ? (
                   <Href
-                    className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                    className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                     href={license.url()}
                   >
                     <span>{license.name()}</span>
                   </Href>
                 ) : (
-                  <span className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1">
+                  <span className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1">
                     {license.name()}
                   </span>
                 )}
               </li>
             )}
             {termsOfService && (
-              <li className="inline-block mt-2 mr-2">
+              <li className="aui-inline-block aui-mt-2 aui-mr-2">
                 <Href
-                  className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                  className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                   href={termsOfService}
                 >
                   <span>{TERMS_OF_SERVICE_TEXT}</span>
@@ -64,9 +67,9 @@ export const Info: React.FunctionComponent = () => {
               </li>
             )}
             {defaultContentType && (
-              <li className="inline-block mt-2 mr-2">
+              <li className="aui-inline-block aui-mt-2 aui-mr-2">
                 <Href
-                  className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                  className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                   href={`${CONTENT_TYPES_SITE}/${defaultContentType}`}
                 >
                   <span>{defaultContentType}</span>
@@ -74,9 +77,9 @@ export const Info: React.FunctionComponent = () => {
               </li>
             )}
             {externalDocs && (
-              <li className="inline-block mt-2 mr-2">
+              <li className="aui-inline-block aui-mt-2 aui-mr-2">
                 <Href
-                  className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                  className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                   href={externalDocs.url()}
                 >
                   <span>{EXTERAL_DOCUMENTATION_TEXT}</span>
@@ -86,9 +89,9 @@ export const Info: React.FunctionComponent = () => {
             {contact && (
               <>
                 {contact.url() && (
-                  <li className="inline-block mt-2 mr-2">
+                  <li className="aui-inline-block aui-mt-2 aui-mr-2">
                     <Href
-                      className="border border-solid border-purple-300 hover:bg-purple-300 hover:text-purple-600 text-purple-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                      className="aui-border aui-border-solid aui-border-purple-300 hover:aui-bg-purple-300 hover:aui-text-purple-600 aui-text-purple-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                       href={contact.url()}
                     >
                       <span>{contact.name() || URL_SUPPORT_TEXT}</span>
@@ -96,9 +99,9 @@ export const Info: React.FunctionComponent = () => {
                   </li>
                 )}
                 {contact.email() && (
-                  <li className="inline-block mt-2 mr-2">
+                  <li className="aui-inline-block aui-mt-2 aui-mr-2">
                     <Href
-                      className="border border-solid border-purple-300 hover:bg-purple-300 hover:text-purple-600 text-purple-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                      className="aui-border aui-border-solid aui-border-purple-300 hover:aui-bg-purple-300 hover:aui-text-purple-600 aui-text-purple-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                       href={`mailto:${contact.email()}`}
                     >
                       <span>{contact.email()}</span>
@@ -108,8 +111,8 @@ export const Info: React.FunctionComponent = () => {
               </>
             )}
             {specId && (
-              <li className="inline-block mt-2 mr-2">
-                <span className="border border-solid border-blue-300 hover:bg-blue-300 hover:text-blue-600 text-blue-500 font-bold no-underline text-xs uppercase rounded px-3 py-1">
+              <li className="aui-inline-block aui-mt-2 aui-mr-2">
+                <span className="aui-border aui-border-solid aui-border-blue-300 hover:aui-bg-blue-300 hover:aui-text-blue-600 aui-text-blue-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1">
                   ID: {specId}
                 </span>
               </li>
@@ -118,13 +121,13 @@ export const Info: React.FunctionComponent = () => {
         )}
 
         {info.hasDescription() && (
-          <div className="mt-4">
+          <div className="aui-mt-4">
             <Markdown>{info.description()}</Markdown>
           </div>
         )}
 
         {asyncapi.hasTags() && (
-          <div className="mt-4">
+          <div className="aui-mt-4">
             <Tags tags={asyncapi.tags()} />
           </div>
         )}

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -43,26 +43,32 @@ export const Message: React.FunctionComponent<Props> = ({
 
   return (
     <div className="panel-item">
-      <div className="panel-item--center px-8">
-        <div className="shadow rounded bg-gray-200 p-4 border bg-gray-100">
+      <div className="panel-item--center aui-px-8">
+        <div className="aui-shadow aui-rounded aui-bg-gray-200 aui-p-4 aui-border aui-bg-gray-100">
           <div>
             {index !== undefined && (
-              <span className="text-gray-700 font-bold mr-2">#{index}</span>
+              <span className="aui-text-gray-700 aui-font-bold aui-mr-2">
+                #{index}
+              </span>
             )}
-            {title && <span className="text-gray-700 mr-2">{title}</span>}
-            <span className="border text-orange-600 rounded text-xs py-0 px-2">
+            {title && (
+              <span className="aui-text-gray-700 aui-mr-2">{title}</span>
+            )}
+            <span className="aui-border aui-text-orange-600 aui-rounded aui-text-xs aui-py-0 aui-px-2">
               {message.uid()}
             </span>
           </div>
 
-          {summary && <p className="text-gray-600 text-sm">{summary}</p>}
+          {summary && (
+            <p className="aui-text-gray-600 aui-text-sm">{summary}</p>
+          )}
 
           {showInfoList && (
-            <ul className="leading-normal mt-2 mb-4 space-x-2 space-y-2">
+            <ul className="aui-leading-normal aui-mt-2 aui-mb-4 aui-space-x-2 aui-space-y-2">
               {contentType && (
-                <li className="inline-block">
+                <li className="aui-inline-block">
                   <Href
-                    className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                    className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                     href={`${CONTENT_TYPES_SITE}/${contentType}`}
                   >
                     <span>{contentType}</span>
@@ -70,9 +76,9 @@ export const Message: React.FunctionComponent<Props> = ({
                 </li>
               )}
               {externalDocs && (
-                <li className="inline-block">
+                <li className="aui-inline-block">
                   <Href
-                    className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                    className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                     href={externalDocs.url()}
                   >
                     <span>{EXTERAL_DOCUMENTATION_TEXT}</span>
@@ -83,16 +89,16 @@ export const Message: React.FunctionComponent<Props> = ({
           )}
 
           {correlationId && (
-            <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
-              <div className="text-sm text-gray-700">
+            <div className="aui-border aui-bg-gray-100 aui-rounded aui-px-4 aui-py-2 aui-mt-2">
+              <div className="aui-text-sm aui-text-gray-700">
                 Correlation ID
-                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                <span className="aui-border aui-text-orange-600 aui-rounded aui-text-xs aui-ml-2 aui-py-0 aui-px-2">
                   {correlationId.location()}
                 </span>
               </div>
 
               {correlationId.hasDescription() && (
-                <div className="mt-2">
+                <div className="aui-mt-2">
                   <Markdown>{correlationId.description()}</Markdown>
                 </div>
               )}
@@ -100,24 +106,24 @@ export const Message: React.FunctionComponent<Props> = ({
           )}
 
           {message.hasDescription() && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Markdown>{message.description()}</Markdown>
             </div>
           )}
 
           {payload && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Schema schemaName="Payload" schema={payload} />
             </div>
           )}
           {headers && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Schema schemaName="Headers" schema={headers} />
             </div>
           )}
 
           {message.hasBindings() && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Bindings bindings={message.bindings()} />
             </div>
           )}
@@ -125,7 +131,7 @@ export const Message: React.FunctionComponent<Props> = ({
           <Extensions item={message} />
 
           {message.hasTags() && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Tags tags={message.tags()} />
             </div>
           )}
@@ -133,7 +139,7 @@ export const Message: React.FunctionComponent<Props> = ({
       </div>
 
       {showExamples && (
-        <div className="panel-item--right px-8">
+        <div className="panel-item--right aui-px-8">
           <MessageExample message={message} />
         </div>
       )}

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -17,8 +17,8 @@ export const MessageExample: React.FunctionComponent<Props> = ({ message }) => {
   const headers = message.headers();
 
   return (
-    <div className="bg-gray-800 px-8 py-4 mt-4 -mx-8 2xl:mx-0 2xl:px-4 2xl:rounded examples">
-      <h4 className="text-white text-lg">Examples</h4>
+    <div className="aui-bg-gray-800 aui-px-8 aui-py-4 aui-mt-4 aui--mx-8 2xl:aui-mx-0 2xl:aui-px-4 2xl:aui-rounded examples">
+      <h4 className="aui-text-white aui-text-lg">Examples</h4>
       {payload && (
         <Example
           type="Payload"
@@ -51,30 +51,30 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
   const [expand, setExpand] = useState(false);
 
   return (
-    <div className="mt-4">
+    <div className="aui-mt-4">
       <div>
         <CollapseButton
           onClick={() => setExpand(prev => !prev)}
           chevronProps={{
-            className: `fill-current text-gray-200 ${
-              expand ? '-rotate-180' : '-rotate-90'
+            className: `aui-fill-current aui-text-gray-200 ${
+              expand ? 'aui--rotate-180' : 'aui--rotate-90'
             }`,
           }}
         >
-          <span className="px-2 py-1 mr-2 text-gray-200 text-sm border rounded focus:outline-none">
+          <span className="aui-px-2 aui-py-1 aui-mr-2 aui-text-gray-200 aui-text-sm aui-border aui-rounded focus:aui-outline-none">
             {type}
           </span>
         </CollapseButton>
       </div>
-      <div className={expand ? 'block' : 'hidden'}>
+      <div className={expand ? 'aui-block' : 'aui-hidden'}>
         {examples && examples.length > 0 ? (
           <ul>
             {examples.map((example, idx) => (
-              <li className="mt-4" key={idx}>
-                <h5 className="text-xs font-bold text-gray-700">
+              <li className="aui-mt-4" key={idx}>
+                <h5 className="aui-text-xs aui-font-bold aui-text-gray-700">
                   Example #{idx + 1}
                 </h5>
-                <div className="mt-1">
+                <div className="aui-mt-1">
                   <JSONSnippet
                     snippet={MessageHelpers.sanitizeExample(example)}
                   />
@@ -83,11 +83,11 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
             ))}
           </ul>
         ) : (
-          <div className="mt-4">
+          <div className="aui-mt-4">
             <JSONSnippet
               snippet={MessageHelpers.generateExample(schema.json())}
             />
-            <h6 className="text-xs font-bold text-gray-700 italic mt-2">
+            <h6 className="aui-text-xs aui-font-bold aui-text-gray-700 aui-italic aui-mt-2">
               This example has been generated automatically.
             </h6>
           </div>

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -13,14 +13,14 @@ export const Messages: React.FunctionComponent = () => {
   }
 
   return (
-    <section id="messages" className="mt-16">
-      <h2 className="2xl:w-7/12 text-3xl font-light mb-4 px-8">
+    <section id="messages" className="aui-mt-16">
+      <h2 className="2xl:aui-w-7/12 aui-text-3xl aui-font-light aui-mb-4 aui-px-8">
         {MESSAGES_TEXT}
       </h2>
       <ul>
         {Array.from(messages).map(([messageName, message], idx) => (
           <li
-            className="mb-4"
+            className="aui-mb-4"
             key={messageName}
             id={`message-${message.uid()}`}
           >

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -40,43 +40,45 @@ export const Operation: React.FunctionComponent<Props> = ({
 
   return (
     <div id={`operation-${type}-${channelName}`}>
-      <div className="panel-item--center px-8">
-        <div className="mb-4">
+      <div className="panel-item--center aui-px-8">
+        <div className="aui-mb-4">
           <h3>
             <span
-              className={`font-mono border uppercase p-1 rounded mr-2 ${
+              className={`aui-font-mono aui-border aui-uppercase aui-p-1 aui-rounded aui-mr-2 ${
                 type === PayloadType.PUBLISH
-                  ? 'border-blue-600 text-blue-500'
-                  : 'border-green-600 text-green-600'
+                  ? 'aui-border-blue-600 aui-text-blue-500'
+                  : 'aui-border-green-600 aui-text-green-600'
               }`}
               title={type}
             >
               {type === PayloadType.PUBLISH ? 'PUB' : 'SUB'}
             </span>{' '}
-            <span className="font-mono text-base">{channelName}</span>
+            <span className="aui-font-mono aui-text-base">{channelName}</span>
           </h3>
         </div>
 
         {channel.hasDescription() && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Markdown>{channel.description()}</Markdown>
           </div>
         )}
         {operationSummary && (
-          <p className="text-gray-600 text-sm mt-2">{operationSummary}</p>
+          <p className="aui-text-gray-600 aui-text-sm aui-mt-2">
+            {operationSummary}
+          </p>
         )}
         {operation.hasDescription() && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Markdown>{operation.description()}</Markdown>
           </div>
         )}
 
         {externalDocs && (
-          <ul className="leading-normal mt-2 mb-4 space-x-2 space-y-2">
+          <ul className="aui-leading-normal aui-mt-2 aui-mb-4 aui-space-x-2 aui-space-y-2">
             {externalDocs && (
-              <li className="inline-block">
+              <li className="aui-inline-block">
                 <Href
-                  className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
+                  className="aui-border aui-border-solid aui-border-orange-300 hover:aui-bg-orange-300 hover:aui-text-orange-600 aui-text-orange-500 aui-font-bold aui-no-underline aui-text-xs aui-uppercase aui-rounded aui-px-3 aui-py-1"
                   href={externalDocs.url()}
                 >
                   <span>{EXTERAL_DOCUMENTATION_TEXT}</span>
@@ -87,10 +89,10 @@ export const Operation: React.FunctionComponent<Props> = ({
         )}
 
         {operationId && (
-          <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
-            <div className="text-sm text-gray-700">
+          <div className="aui-border aui-bg-gray-100 aui-rounded aui-px-4 aui-py-2 aui-mt-2">
+            <div className="aui-text-sm aui-text-gray-700">
               Operation ID
-              <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+              <span className="aui-border aui-text-orange-600 aui-rounded aui-text-xs aui-ml-2 aui-py-0 aui-px-2">
                 {operationId}
               </span>
             </div>
@@ -98,7 +100,7 @@ export const Operation: React.FunctionComponent<Props> = ({
         )}
 
         {parameters && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Schema
               schemaName="Parameters"
               schema={parameters}
@@ -108,7 +110,7 @@ export const Operation: React.FunctionComponent<Props> = ({
         )}
 
         {operation.hasBindings() && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Bindings
               name="Operation Bindings"
               bindings={operation.bindings()}
@@ -116,7 +118,7 @@ export const Operation: React.FunctionComponent<Props> = ({
           </div>
         )}
         {channel.hasBindings() && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Bindings name="Channel Bindings" bindings={channel.bindings()} />
           </div>
         )}
@@ -124,30 +126,30 @@ export const Operation: React.FunctionComponent<Props> = ({
         <Extensions item={operation} />
 
         {operation.hasTags() && (
-          <div className="mt-2">
+          <div className="aui-mt-2">
             <Tags tags={operation.tags()} />
           </div>
         )}
       </div>
 
-      <div className="w-full mt-4">
+      <div className="aui-w-full aui-mt-4">
         {operation.hasMultipleMessages() ? (
-          <div className="mt-2">
-            <p className="px-8">
+          <div className="aui-mt-2">
+            <p className="aui-px-8">
               Accepts <strong>one of</strong> the following messages:
             </p>
             <ul>
               {operation.messages().map((msg, idx) => (
-                <li className="mt-4" key={idx}>
+                <li className="aui-mt-4" key={idx}>
                   <Message message={msg} index={idx} showExamples={true} />
                 </li>
               ))}
             </ul>
           </div>
         ) : (
-          <div className="mt-2">
-            <p className="px-8">Accepts the following message:</p>
-            <div className="mt-2">
+          <div className="aui-mt-2">
+            <p className="aui-px-8">Accepts the following message:</p>
+            <div className="aui-mt-2">
               <Message
                 message={(operation.message as any)(0)}
                 showExamples={true}

--- a/library/src/containers/Operations/Operations.tsx
+++ b/library/src/containers/Operations/Operations.tsx
@@ -17,7 +17,7 @@ export const Operations: React.FunctionComponent = () => {
   Object.entries(channels).forEach(([channelName, channel]) => {
     if (channel.hasPublish()) {
       operationsList.push(
-        <li className="mb-12" key={`pub-${channelName}`}>
+        <li className="aui-mb-12" key={`pub-${channelName}`}>
           <Operation
             type={PayloadType.PUBLISH}
             operation={channel.publish()}
@@ -29,7 +29,7 @@ export const Operations: React.FunctionComponent = () => {
     }
     if (channel.hasSubscribe()) {
       operationsList.push(
-        <li className="mb-12" key={`sub-${channelName}`}>
+        <li className="aui-mb-12" key={`sub-${channelName}`}>
           <Operation
             type={PayloadType.SUBSCRIBE}
             operation={channel.subscribe()}
@@ -42,8 +42,8 @@ export const Operations: React.FunctionComponent = () => {
   });
 
   return (
-    <section id="operations" className="mt-16">
-      <h2 className="2xl:w-7/12 text-3xl font-light mb-4 px-8">
+    <section id="operations" className="aui-mt-16">
+      <h2 className="2xl:aui-w-7/12 aui-text-3xl aui-font-light aui-mb-4 aui-px-8">
         {OPERATIONS_TEXT}
       </h2>
       <ul>{operationsList}</ul>

--- a/library/src/containers/Servers/Server.tsx
+++ b/library/src/containers/Servers/Server.tsx
@@ -27,28 +27,28 @@ export const Server: React.FunctionComponent<Props> = ({
 
   return (
     <div className="panel-item">
-      <div className="panel-item--center px-8">
-        <div className="shadow rounded bg-gray-200 p-4 border bg-gray-100">
+      <div className="panel-item--center aui-px-8">
+        <div className="aui-shadow aui-rounded aui-bg-gray-200 aui-p-4 aui-border aui-bg-gray-100">
           <div>
-            <span className="font-mono text-base">{server.url()}</span>
-            <span className="bg-teal-500 font-bold no-underline text-white uppercase rounded mx-2 px-2 py-1 text-sm">
+            <span className="aui-font-mono aui-text-base">{server.url()}</span>
+            <span className="aui-bg-teal-500 aui-font-bold aui-no-underline aui-text-white aui-uppercase aui-rounded aui-mx-2 aui-px-2 aui-py-1 aui-text-sm">
               {protocolVersion
                 ? `${server.protocol()} ${protocolVersion}`
                 : server.protocol()}
             </span>
-            <span className="bg-blue-500 font-bold no-underline text-white uppercase rounded px-2 py-1 text-sm">
+            <span className="aui-bg-blue-500 aui-font-bold aui-no-underline aui-text-white aui-uppercase aui-rounded aui-px-2 aui-py-1 aui-text-sm">
               {serverName}
             </span>
           </div>
 
           {server.hasDescription() && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Markdown>{server.description()}</Markdown>
             </div>
           )}
 
           {urlVariables && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Schema
                 schemaName="URL Variables"
                 schema={urlVariables}
@@ -62,7 +62,7 @@ export const Server: React.FunctionComponent<Props> = ({
           )}
 
           {server.hasBindings() && (
-            <div className="mt-2">
+            <div className="aui-mt-2">
               <Bindings bindings={server.bindings()} />
             </div>
           )}

--- a/library/src/containers/Servers/ServerSecurity.tsx
+++ b/library/src/containers/Servers/ServerSecurity.tsx
@@ -42,11 +42,11 @@ export const ServerSecurity: React.FunctionComponent<Props> = ({
   }
 
   return (
-    <div className="text-sm mt-4">
-      <h5 className="text-gray-700 text-base">Security:</h5>
+    <div className="aui-text-sm aui-mt-4">
+      <h5 className="aui-text-gray-700 aui-text-base">Security:</h5>
       <ul>
         {serverSecurities.map((security, idx) => (
-          <li className="mt-2" key={idx}>
+          <li className="aui-mt-2" key={idx}>
             {security}
           </li>
         ))}
@@ -77,7 +77,7 @@ const ServerSecurityItem: React.FunctionComponent<ServerSecurityItemProps> = ({
   }
   if (securitySchema.openIdConnectUrl()) {
     schemas.push(
-      <Href href={securitySchema.openIdConnectUrl()} className="underline">
+      <Href href={securitySchema.openIdConnectUrl()} className="aui-underline">
         Connect URL
       </Href>,
     );
@@ -94,58 +94,58 @@ const ServerSecurityItem: React.FunctionComponent<ServerSecurityItemProps> = ({
 
       return (
         <div
-          className="px-4 py-2 ml-2 mb-2 border border-gray-400 bg-gray-100 rounded"
+          className="aui-px-4 aui-py-2 aui-ml-2 aui-mb-2 aui-border aui-border-gray-400 aui-bg-gray-100 aui-rounded"
           key={flowName}
         >
           <div>
-            <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
               Flow:
             </span>
-            <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
               {ServerHelpers.flowName(flowName)}
             </span>
           </div>
 
           {authorizationUrl && (
-            <div className="mt-1">
-              <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <div className="aui-mt-1">
+              <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
                 Auth URL:
               </span>
-              <Href href={authorizationUrl} className="underline">
+              <Href href={authorizationUrl} className="aui-underline">
                 {authorizationUrl}
               </Href>
             </div>
           )}
           {tokenUrl && (
-            <div className="mt-1">
-              <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <div className="aui-mt-1">
+              <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
                 Token URL:
               </span>
-              <Href href={tokenUrl} className="underline">
+              <Href href={tokenUrl} className="aui-underline">
                 {tokenUrl}
               </Href>
             </div>
           )}
           {refreshUrl && (
-            <div className="mt-1">
-              <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <div className="aui-mt-1">
+              <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
                 Refresh URL:
               </span>
-              <Href href={refreshUrl} className="underline">
+              <Href href={refreshUrl} className="aui-underline">
                 {refreshUrl}
               </Href>
             </div>
           )}
           {scopes && (
-            <div className="mt-1">
-              <span className="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">
+            <div className="aui-mt-1">
+              <span className="aui-text-xs aui-font-bold aui-text-gray-600 aui-mt-1 aui-mr-1 aui-uppercase">
                 Scopes:
               </span>
-              <ul className="inline-block">
+              <ul className="aui-inline-block">
                 {scopes &&
                   Object.entries(scopes).map(([scopeName, scopeDesc]) => (
                     <li
-                      className="inline-block font-bold no-underline bg-indigo-400 text-white text-xs rounded py-0 px-1 ml-1"
+                      className="aui-inline-block aui-font-bold aui-no-underline aui-bg-indigo-400 aui-text-white aui-text-xs aui-rounded aui-py-0 aui-px-1 aui-ml-1"
                       title={scopeDesc}
                       key={scopeName}
                     >
@@ -165,10 +165,10 @@ const ServerSecurityItem: React.FunctionComponent<ServerSecurityItemProps> = ({
         <span>
           {ServerHelpers.securityType(securitySchema.type())}
           {schemas.length > 0 && (
-            <ul className="inline-block ml-2">
+            <ul className="aui-inline-block aui-ml-2">
               {schemas.map((schema, idx) => (
                 <li
-                  className="inline-block font-bold no-underline bg-blue-400 text-white text-xs uppercase rounded px-2 py-0 ml-1"
+                  className="aui-inline-block aui-font-bold aui-no-underline aui-bg-blue-400 aui-text-white aui-text-xs aui-uppercase aui-rounded aui-px-2 aui-py-0 aui-ml-1"
                   key={idx}
                 >
                   {schema}
@@ -186,7 +186,7 @@ const ServerSecurityItem: React.FunctionComponent<ServerSecurityItemProps> = ({
       )}
 
       {renderedFlows && renderedFlows.length > 0 && (
-        <ul className="my-2">
+        <ul className="aui-my-2">
           <li>{renderedFlows}</li>
         </ul>
       )}

--- a/library/src/containers/Servers/Servers.tsx
+++ b/library/src/containers/Servers/Servers.tsx
@@ -13,13 +13,13 @@ export const Servers: React.FunctionComponent = () => {
   }
 
   return (
-    <section id="servers" className="mt-16">
-      <h2 className="2xl:w-7/12 text-3xl font-light mb-4 px-8">
+    <section id="servers" className="aui-mt-16">
+      <h2 className="2xl:aui-w-7/12 aui-text-3xl aui-font-light aui-mb-4 aui-px-8">
         {SERVERS_TEXT}
       </h2>
       <ul>
         {Object.entries(servers).map(([serverName, server]) => (
-          <li className="mb-4" key={serverName}>
+          <li className="aui-mb-4" key={serverName}>
             <Server serverName={serverName} server={server} key={serverName} />
           </li>
         ))}

--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -36,7 +36,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
   return (
     <SidebarContext.Provider value={{ setShowSidebar }}>
       <div
-        className="burger-menu rounded-full h-16 w-16 bg-white fixed bottom-16 right-8 flex items-center justify-center z-30 cursor-pointer shadow-md bg-teal-500"
+        className="burger-menu aui-rounded-full aui-h-16 aui-w-16 aui-bg-white aui-fixed aui-bottom-16 aui-right-8 aui-flex aui-items-center aui-justify-center aui-z-30 aui-cursor-pointer aui-shadow-md aui-bg-teal-500"
         onClick={() => setShowSidebar(prev => !prev)}
         data-lol={showSidebar}
       >
@@ -44,7 +44,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
           viewBox="0 0 100 70"
           width="40"
           height="30"
-          className="fill-current text-gray-200"
+          className="aui-fill-current aui-text-gray-200"
         >
           <rect width="100" height="10" />
           <rect y="30" width="100" height="10" />
@@ -53,16 +53,13 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
       </div>
       <div
         className={`${
-          showSidebar ? 'block fixed w-full' : 'hidden'
-        } sidebar relative w-64 max-h-screen h-full bg-gray-200 shadow z-20`}
-        // className={`${
-        //   showSidebar ? 'block fixed w-full' : 'hidden'
-        // } sidebar bg-gray-200 font-sans font-light px-4 py-8 z-20 shadow overflow-auto`}
+          showSidebar ? 'aui-block aui-fixed aui-w-full' : 'aui-hidden'
+        } sidebar aui-relative aui-w-64 aui-max-h-screen aui-h-full aui-bg-gray-200 aui-shadow aui-z-20`}
       >
         <div
           className={`${
-            showSidebar ? 'w-full' : ''
-          } block fixed max-h-screen h-full font-sans px-4 pt-8 pb-16 overflow-y-auto bg-gray-200`}
+            showSidebar ? 'aui-w-full' : ''
+          } aui-block aui-fixed aui-max-h-screen aui-h-full aui-font-sans aui-px-4 aui-pt-8 aui-pb-16 aui-overflow-y-auto aui-bg-gray-200`}
         >
           <div className="sidebar--content">
             <div>
@@ -72,16 +69,16 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
                   alt={`${info.title()} logo, ${info.version()} version`}
                 />
               ) : (
-                <h1 className="text-2xl font-light">
+                <h1 className="aui-text-2xl aui-font-light">
                   {info.title()} {info.version()}
                 </h1>
               )}
             </div>
 
-            <ul className="text-sm mt-10 relative">
-              <li className="mb-3">
+            <ul className="aui-text-sm aui-mt-10 aui-relative">
+              <li className="aui-mb-3">
                 <a
-                  className="text-gray-700 no-underline hover:text-gray-900"
+                  className="aui-text-gray-700 aui-no-underline hover:aui-text-gray-900"
                   href="#introduction"
                   onClick={() => setShowSidebar(false)}
                 >
@@ -89,9 +86,9 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
                 </a>
               </li>
               {asyncapi.hasServers() && (
-                <li className="mb-3">
+                <li className="aui-mb-3">
                   <a
-                    className="text-gray-700 no-underline hover:text-gray-900"
+                    className="aui-text-gray-700 aui-no-underline hover:aui-text-gray-900"
                     href="#servers"
                     onClick={() => setShowSidebar(false)}
                   >
@@ -101,9 +98,9 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
               )}
               {asyncapi.hasChannels() && (
                 <>
-                  <li className="mb-3 mt-9">
+                  <li className="aui-mb-3 aui-mt-9">
                     <a
-                      className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
+                      className="aui-text-xs aui-uppercase aui-text-gray-700 aui-mt-10 aui-mb-4 aui-font-thin hover:aui-text-gray-900"
                       href="#operations"
                       onClick={() => setShowSidebar(false)}
                     >
@@ -112,23 +109,23 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
                     <Operations />
                   </li>
                   {allMessages.size > 0 && (
-                    <li className="mb-3 mt-9">
+                    <li className="aui-mb-3 aui-mt-9">
                       <a
-                        className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
+                        className="aui-text-xs aui-uppercase aui-text-gray-700 aui-mt-10 aui-mb-4 aui-font-thin hover:aui-text-gray-900"
                         href="#messages"
                         onClick={() => setShowSidebar(false)}
                       >
                         Messages
                       </a>
-                      <ul className="text-sm mt-2">
+                      <ul className="aui-text-sm aui-mt-2">
                         {Array.from(allMessages.keys()).map(messageName => (
                           <li key={messageName}>
                             <a
-                              className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
+                              className="aui-flex aui-break-words aui-no-underline aui-text-gray-700 aui-mt-2 hover:aui-text-gray-900"
                               href={`#message-${messageName}`}
                               onClick={() => setShowSidebar(false)}
                             >
-                              <div className="break-all inline-block">
+                              <div className="aui-break-all aui-inline-block">
                                 {messageName}
                               </div>
                             </a>
@@ -171,7 +168,7 @@ export const OperationsList: React.FunctionComponent = () => {
     }
   });
 
-  return <ul className="text-sm mt-2">{operationsList}</ul>;
+  return <ul className="aui-text-sm aui-mt-2">{operationsList}</ul>;
 };
 
 export const OperationsByRootTags: React.FunctionComponent = () => {
@@ -369,14 +366,18 @@ const OperationsByTagItem: React.FunctionComponent<OperationsByTagItemProps> = (
       <CollapseButton
         onClick={() => setExpand(prev => !prev)}
         chevronProps={{
-          className: expand ? '-rotate-180' : '-rotate-90',
+          className: expand ? 'aui--rotate-180' : 'aui--rotate-90',
         }}
       >
-        <span className="text-sm inline-block mt-1 font-extralight">
+        <span className="aui-text-sm aui-inline-block aui-mt-1 aui-font-extralight">
           {tagName}
         </span>
       </CollapseButton>
-      <ul className={`${expand ? 'block' : 'hidden'} text-sm mt-2 font-light`}>
+      <ul
+        className={`${
+          expand ? 'aui-block' : 'aui-hidden'
+        } aui-text-sm aui-mt-2 aui-font-light`}
+      >
         {children}
       </ul>
     </div>
@@ -395,17 +396,17 @@ const OperationsPubItem: React.FunctionComponent<OperationsPubItemProps> = ({
   return (
     <li>
       <a
-        className="flex no-underline text-gray-700 mb-2 hover:text-gray-900"
+        className="aui-flex aui-no-underline aui-text-gray-700 aui-mb-2 hover:aui-text-gray-900"
         href={`#operation-publish-${channelName}`}
         onClick={() => setShowSidebar(false)}
       >
         <span
-          className="bg-blue-600 font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded text-xs"
+          className="aui-bg-blue-600 aui-font-bold aui-h-6 aui-no-underline aui-text-white aui-uppercase aui-p-1 mr-2 aui-rounded aui-text-xs"
           title="Publish"
         >
           Pub
         </span>
-        <span className="break-all inline-block">{channelName}</span>
+        <span className="aui-break-all aui-inline-block">{channelName}</span>
       </a>
     </li>
   );
@@ -419,17 +420,17 @@ const OperationsSubItem: React.FunctionComponent<OperationsPubItemProps> = ({
   return (
     <li>
       <a
-        className="flex no-underline text-gray-700 mb-2 hover:text-gray-900"
+        className="aui-flex aui-no-underline aui-text-gray-700 aui-mb-2 hover:aui-text-gray-900"
         href={`#operation-subscribe-${channelName}`}
         onClick={() => setShowSidebar(false)}
       >
         <span
-          className="bg-green-600 font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded text-xs"
+          className="aui-bg-green-600 aui-font-bold aui-h-6 aui-no-underline aui-text-white aui-uppercase aui-p-1 mr-2 aui-rounded aui-text-xs"
           title="Subscribe"
         >
           SUB
         </span>
-        <span className="break-all inline-block">{channelName}</span>
+        <span className="aui-break-all aui-inline-block">{channelName}</span>
       </a>
     </li>
   );

--- a/library/src/styles/default.css
+++ b/library/src/styles/default.css
@@ -6,65 +6,65 @@
 
 @layer components {
   .container\:base .burger-menu {
-    @apply lg:hidden;
+    @apply lg:aui-hidden;
   }
 
   .container\:xl .burger-menu {
   }
 
   .container\:base .sidebar {
-    @apply lg:relative lg:block lg:w-64 lg:h-auto;
+    @apply lg:aui-relative lg:aui-block lg:aui-w-64 lg:aui-h-auto;
   }
 
   .container\:xl .sidebar {
   }
 
   .container\:base .sidebar--content {
-    @apply lg:w-56;
+    @apply lg:aui-w-56;
   }
 
   .container\:xl .sidebar--content {
-    @apply absolute;
+    @apply aui-absolute;
     left: 50%;
     transform: translate(-50%, 0);
   }
 
   .container\:base .panel-item {
-    @apply 2xl:flex;
+    @apply 2xl:aui-flex;
   }
 
   .container\:xl .panel-item {
-    @apply block;
+    @apply aui-block;
   }
 
   .container\:base .panel--center .panel-item--center {
-    @apply 2xl:w-7/12;
+    @apply 2xl:aui-w-7/12;
   }
 
   .container\:base .panel--center .panel-item--right {
-    @apply 2xl:w-5/12;
+    @apply 2xl:aui-w-5/12;
   }
 
   .container\:xl .panel--center .panel-item--center {
-    @apply w-full;
+    @apply aui-w-full;
   }
 
   .container\:xl .panel--center .panel-item--right {
-    @apply w-full;
+    @apply aui-w-full;
   }
 
   .container\:base .examples {
-    @apply 2xl:p-0 2xl:mt-0;
+    @apply 2xl:aui-p-0 2xl:aui-mt-0;
   }
 
   .container\:xl .examples {
   }
 
   .container\:base .panel--right {
-    @apply hidden 2xl:block 2xl:w-5/12;
+    @apply aui-hidden 2xl:aui-block 2xl:aui-w-5/12;
   }
 
   .container\:xl .panel--right {
-    @apply hidden;
+    @apply aui-hidden;
   }
 }

--- a/library/tailwind.config.js
+++ b/library/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  prefix: 'aui-',
   // Purge works on production env
   purge: ['./src/**/*.tsx'],
   darkMode: false, // or 'media' or 'class'

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -4,81 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@asyncapi/avro-schema-parser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.2.1.tgz",
-      "integrity": "sha512-RZJaHsdYM4dChYSrb/TWrVCn/r2qcus+9/8iLL8+SMINHb0ECgH8tFZFJpr3Tq+LV2SBFaRQ+9kuecjQ8BNDSA=="
-    },
-    "@asyncapi/openapi-schema-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-2.0.1.tgz",
-      "integrity": "sha512-algbtdM1gcAOa8+V8kp7WeBhdaNac82jmZUXx8YjyNfRVo02N2juDrjeBAGJd+FNva9Mb4MM7qfkJoAFpTL5VQ==",
-      "requires": {
-        "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0"
-      }
-    },
-    "@asyncapi/parser": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.5.2.tgz",
-      "integrity": "sha512-Mv7B/c8jWx64pLvDYN51YA8RM7H6pbzBCcEM49nZd/Y0J3RqiGXXJbUqW8tnfiitAG5oCC467K3fdUz/XubR9A==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.7.8",
-        "@fmvilas/pseudo-yaml-ast": "^0.3.1",
-        "ajv": "^6.10.1",
-        "js-yaml": "^3.13.1",
-        "json-to-ast": "^2.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "node-fetch": "^2.6.0",
-        "tiny-merge-patch": "^0.1.2"
-      }
-    },
-    "@asyncapi/react-component": {
-      "version": "1.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.9.tgz",
-      "integrity": "sha512-WgqGb+nuv+k9EG11DSmzorRdXoG8I8BMn5VmZLDt8pxUPDUXfR1a0muhI2KP/rhSrwqhjCwTAJ2HxJXGzjtYsQ==",
-      "requires": {
-        "@asyncapi/avro-schema-parser": "^0.2.0",
-        "@asyncapi/openapi-schema-parser": "^2.0.0",
-        "@asyncapi/parser": "^1.5.2",
-        "highlight.js": "^10.7.2",
-        "isomorphic-dompurify": "^0.13.0",
-        "marked": "^2.1.1",
-        "openapi-sampler": "^1.0.0",
-        "use-resize-observer": "^7.0.0"
-      }
-    },
-    "@asyncapi/specs": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.8.tgz",
-      "integrity": "sha512-GvyUo8rKAY25XdhM2dYqv4yf6gzgiNRazLxbeQfeD5oXu4aEs/rkpcgHPeb3ckA6xXiyzdBnpVYhJOcPvgr46g=="
-    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -1383,14 +1308,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@fmvilas/pseudo-yaml-ast": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@fmvilas/pseudo-yaml-ast/-/pseudo-yaml-ast-0.3.1.tgz",
-      "integrity": "sha512-8OAB74W2a9M3k9bjYD8AjVXkX+qO8c0SqNT5HlgOqx7AxSw8xdksEcZp7gFtfi+4njSxT6+76ZR+1ubjAwQHOg==",
-      "requires": {
-        "yaml-ast-parser": "0.0.43"
-      }
-    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.35",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
@@ -1894,11 +1811,6 @@
         }
       }
     },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1914,14 +1826,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
-    },
-    "@openapi-contrib/openapi-schema-to-json-schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.1.1.tgz",
-      "integrity": "sha512-FMvdhv9Jr9tULjJAQaQzhCmNYYj2vQFVnl7CGlLAImZvJal71oedXMGszpPaZTLftAk5TCHqjnirig+P6LZxug==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3"
-      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -2046,11 +1950,6 @@
         "loader-utils": "^1.2.3"
       }
     },
-    "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
-    },
     "@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -2099,14 +1998,6 @@
       "dev": true,
       "requires": {
         "@types/tern": "*"
-      }
-    },
-    "@types/dompurify": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.2.tgz",
-      "integrity": "sha512-8nNWfAa8/oZjH3OLY5Wsxu9ueo0NwVUotIi353g0P2+N5BuTLJyAVOnF4xBUY0NyFUGJHY05o1pO2bqLto+lmA==",
-      "requires": {
-        "@types/trusted-types": "*"
       }
     },
     "@types/eslint-visitor-keys": {
@@ -2176,7 +2067,8 @@
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
     },
     "@types/node": {
       "version": "12.7.2",
@@ -2256,11 +2148,6 @@
       "requires": {
         "@types/estree": "*"
       }
-    },
-    "@types/trusted-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.1.tgz",
-      "integrity": "sha512-TmhE+/eI8PP7EwT9EbK8i74F1ryNn0LToCyEaLpN+X+A3LS1j4CpsCk9Jwq6Y2Uu7w9wdrKl6bujdj5LSsDKKA=="
     },
     "@types/yargs": {
       "version": "16.0.3",
@@ -2530,7 +2417,8 @@
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -2542,37 +2430,11 @@
         "negotiator": "0.6.2"
       }
     },
-    "acorn": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-      "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w=="
-    },
-    "acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "requires": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-        }
-      }
-    },
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
-    },
-    "acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
     "address": {
       "version": "1.1.2",
@@ -2627,18 +2489,11 @@
         }
       }
     },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2727,6 +2582,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2909,7 +2765,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -3751,7 +3608,8 @@
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
@@ -3984,7 +3842,8 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -4287,11 +4146,6 @@
         "q": "^1.1.2"
       }
     },
-    "code-error-fragment": {
-      "version": "0.0.230",
-      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -4356,6 +4210,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4950,26 +4805,6 @@
         }
       }
     },
-    "cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-    },
-    "cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "requires": {
-        "cssom": "~0.3.6"
-      },
-      "dependencies": {
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        }
-      }
-    },
     "csstype": {
       "version": "2.6.17",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
@@ -5007,16 +4842,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-      "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
-      }
-    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -5030,11 +4855,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5059,7 +4879,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -5167,7 +4988,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5338,21 +5160,6 @@
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
-    "domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "requires": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-        }
-      }
-    },
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
@@ -5361,11 +5168,6 @@
       "requires": {
         "domelementtype": "1"
       }
-    },
-    "dompurify": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.9.tgz",
-      "integrity": "sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -5668,18 +5470,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      }
     },
     "eslint": {
       "version": "6.8.0",
@@ -6187,7 +5977,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -6210,12 +6001,14 @@
     "estraverse": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -6585,7 +6378,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -6627,12 +6421,14 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fast-memoize": {
       "version": "2.5.2",
@@ -6859,11 +6655,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6884,16 +6675,6 @@
         "semver": "^5.6.0",
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
-      }
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -7177,11 +6958,6 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -7350,11 +7126,6 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7430,14 +7201,6 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
-    },
-    "html-encoding-sniffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-      "requires": {
-        "whatwg-encoding": "^1.0.5"
-      }
     },
     "html-entities": {
       "version": "1.4.0",
@@ -7566,16 +7329,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "http-proxy-middleware": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
@@ -7605,19 +7358,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8109,11 +7854,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
     "is-regex": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
@@ -8203,16 +7943,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-dompurify": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-0.13.0.tgz",
-      "integrity": "sha512-j2/kt/PGbxvfeEm1uiRLlttZkQdn3hFe1rMr/wm3qFnMXSIw0Nmqu79k+TIoSj+KOwO98Sz9TbuNHU7ejv7IZA==",
-      "requires": {
-        "@types/dompurify": "^2.1.0",
-        "dompurify": "^2.2.7",
-        "jsdom": "^16.5.2"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -10062,6 +9792,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10072,40 +9803,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
-    },
-    "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
-      "requires": {
-        "abab": "^2.0.5",
-        "acorn": "^8.2.4",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.1",
-        "domexception": "^2.0.1",
-        "escodegen": "^2.0.0",
-        "form-data": "^3.0.0",
-        "html-encoding-sniffer": "^2.0.1",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^6.1.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
-        "xml-name-validator": "^3.0.0"
-      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -10124,14 +9821,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-pointer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
-      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
-      "requires": {
-        "foreach": "^2.0.4"
-      }
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -10141,7 +9830,8 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -10163,15 +9853,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
-    },
-    "json-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-      "requires": {
-        "code-error-fragment": "0.0.230",
-        "grapheme-splitter": "^1.0.4"
-      }
     },
     "json3": {
       "version": "3.3.3",
@@ -10296,6 +9977,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -10418,11 +10100,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -10552,11 +10229,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.1.tgz",
-      "integrity": "sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -10738,12 +10410,14 @@
     "mime-db": {
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.30",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
       "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "dev": true,
       "requires": {
         "mime-db": "1.47.0"
       }
@@ -10973,11 +10647,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -11169,7 +10838,8 @@
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -11363,15 +11033,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "openapi-sampler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.1.tgz",
-      "integrity": "sha512-qBjxkSLJV183zTTs4fgxtU/iWSLUUu2aH2+5ddWkNhV7p8CSe/mnAgoLkEbMfHtel6yr9NF+vjUWqfM+iiwORQ==",
-      "requires": {
-        "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
-      }
-    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -11395,6 +11056,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -11590,11 +11252,6 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
-    },
-    "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "parseurl": {
       "version": "1.3.3",
@@ -12704,7 +12361,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -12826,7 +12484,8 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -12886,7 +12545,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -13666,11 +13326,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -13901,7 +13556,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -13972,14 +13628,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-      "requires": {
-        "xmlchars": "^2.2.0"
-      }
     },
     "scheduler": {
       "version": "0.19.1",
@@ -14496,7 +14144,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -14603,7 +14252,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -15049,7 +14699,8 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",
@@ -15209,11 +14860,6 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
-    "tiny-merge-patch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
-      "integrity": "sha1-Lo3tGcVuoV29OtTtXbHI5a1UTDw="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15277,24 +14923,6 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      }
-    },
-    "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
-    },
     "ts-pnp": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.4.tgz",
@@ -15347,6 +14975,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -15476,7 +15105,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -15546,6 +15176,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -15613,14 +15244,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "use-resize-observer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-7.0.0.tgz",
-      "integrity": "sha512-+RjrQsk/mL8aKy4TGBDiPkUv6whyeoGDMIZYk0gOGHOlnrsjImC+jG6lfAFcBCKAG9epGRL419adhDNdkDCQkA==",
-      "requires": {
-        "resize-observer-polyfill": "^1.5.1"
-      }
     },
     "util": {
       "version": "0.10.3",
@@ -15724,16 +15347,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "w3c-xmlserializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
-      "requires": {
-        "xml-name-validator": "^3.0.0"
       }
     },
     "walker": {
@@ -15883,11 +15499,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
       "version": "4.40.2",
@@ -16247,6 +15858,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -16260,17 +15872,8 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-    },
-    "whatwg-url": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
-      "requires": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
-      }
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
@@ -16303,7 +15906,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "workbox-background-sync": {
       "version": "4.3.1",
@@ -16563,20 +16167,17 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw=="
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "xregexp": {
       "version": "4.0.0",
@@ -16607,11 +16208,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
-    },
-    "yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/web-component/package-lock.json
+++ b/web-component/package-lock.json
@@ -4,115 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@asyncapi/avro-schema-parser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.2.1.tgz",
-      "integrity": "sha512-RZJaHsdYM4dChYSrb/TWrVCn/r2qcus+9/8iLL8+SMINHb0ECgH8tFZFJpr3Tq+LV2SBFaRQ+9kuecjQ8BNDSA=="
-    },
-    "@asyncapi/openapi-schema-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-2.0.1.tgz",
-      "integrity": "sha512-algbtdM1gcAOa8+V8kp7WeBhdaNac82jmZUXx8YjyNfRVo02N2juDrjeBAGJd+FNva9Mb4MM7qfkJoAFpTL5VQ==",
-      "requires": {
-        "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0"
-      }
-    },
-    "@asyncapi/parser": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.5.2.tgz",
-      "integrity": "sha512-Mv7B/c8jWx64pLvDYN51YA8RM7H6pbzBCcEM49nZd/Y0J3RqiGXXJbUqW8tnfiitAG5oCC467K3fdUz/XubR9A==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.7.8",
-        "@fmvilas/pseudo-yaml-ast": "^0.3.1",
-        "ajv": "^6.10.1",
-        "js-yaml": "^3.13.1",
-        "json-to-ast": "^2.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "node-fetch": "^2.6.0",
-        "tiny-merge-patch": "^0.1.2"
-      }
-    },
-    "@asyncapi/react-component": {
-      "version": "1.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.9.tgz",
-      "integrity": "sha512-WgqGb+nuv+k9EG11DSmzorRdXoG8I8BMn5VmZLDt8pxUPDUXfR1a0muhI2KP/rhSrwqhjCwTAJ2HxJXGzjtYsQ==",
-      "requires": {
-        "@asyncapi/avro-schema-parser": "^0.2.0",
-        "@asyncapi/openapi-schema-parser": "^2.0.0",
-        "@asyncapi/parser": "^1.5.2",
-        "highlight.js": "^10.7.2",
-        "isomorphic-dompurify": "^0.13.0",
-        "marked": "^2.1.1",
-        "openapi-sampler": "^1.0.0",
-        "use-resize-observer": "^7.0.0"
-      }
-    },
-    "@asyncapi/specs": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.8.tgz",
-      "integrity": "sha512-GvyUo8rKAY25XdhM2dYqv4yf6gzgiNRazLxbeQfeD5oXu4aEs/rkpcgHPeb3ckA6xXiyzdBnpVYhJOcPvgr46g=="
-    },
-    "@fmvilas/pseudo-yaml-ast": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@fmvilas/pseudo-yaml-ast/-/pseudo-yaml-ast-0.3.1.tgz",
-      "integrity": "sha512-8OAB74W2a9M3k9bjYD8AjVXkX+qO8c0SqNT5HlgOqx7AxSw8xdksEcZp7gFtfi+4njSxT6+76ZR+1ubjAwQHOg==",
-      "requires": {
-        "yaml-ast-parser": "0.0.43"
-      }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
-    "@openapi-contrib/openapi-schema-to-json-schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.1.1.tgz",
-      "integrity": "sha512-FMvdhv9Jr9tULjJAQaQzhCmNYYj2vQFVnl7CGlLAImZvJal71oedXMGszpPaZTLftAk5TCHqjnirig+P6LZxug==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
-    },
-    "@types/dompurify": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.2.tgz",
-      "integrity": "sha512-8nNWfAa8/oZjH3OLY5Wsxu9ueo0NwVUotIi353g0P2+N5BuTLJyAVOnF4xBUY0NyFUGJHY05o1pO2bqLto+lmA==",
-      "requires": {
-        "@types/trusted-types": "*"
-      }
-    },
-    "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
-    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -128,11 +19,6 @@
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "@types/trusted-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.1.tgz",
-      "integrity": "sha512-TmhE+/eI8PP7EwT9EbK8i74F1ryNn0LToCyEaLpN+X+A3LS1j4CpsCk9Jwq6Y2Uu7w9wdrKl6bujdj5LSsDKKA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -321,65 +207,17 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "abab": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
     "acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true
     },
-    "acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "requires": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-        }
-      }
-    },
-    "acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -430,11 +268,6 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
-    },
-    "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -519,11 +352,6 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true,
       "optional": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -693,11 +521,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
-    },
-    "browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -878,11 +701,6 @@
         "get-intrinsic": "^1.0.0"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -1015,11 +833,6 @@
         "wrap-ansi": "^5.1.0"
       }
     },
-    "code-error-fragment": {
-      "version": "0.0.230",
-      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1044,14 +857,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1204,26 +1009,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-    },
-    "cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "requires": {
-        "cssom": "~0.3.6"
-      },
-      "dependencies": {
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        }
-      }
-    },
     "csstype": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
@@ -1246,16 +1031,6 @@
         "type": "^1.0.1"
       }
     },
-    "data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-      "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1271,21 +1046,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1337,11 +1102,6 @@
         }
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -1382,26 +1142,6 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
-    },
-    "domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "requires": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-        }
-      }
-    },
-    "dompurify": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.9.tgz",
-      "integrity": "sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -1517,31 +1257,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        }
-      }
-    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1551,11 +1266,6 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -1579,11 +1289,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "events": {
       "version": "3.2.0",
@@ -1751,17 +1456,14 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -1846,21 +1548,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2000,11 +1687,6 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2098,11 +1780,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2123,76 +1800,11 @@
         "parse-passwd": "^1.0.0"
       }
     },
-    "html-encoding-sniffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-      "requires": {
-        "whatwg-encoding": "^1.0.5"
-      }
-    },
-    "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
     },
     "ieee754": {
       "version": "1.2.1",
@@ -2387,11 +1999,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2422,80 +2029,10 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-dompurify": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-0.13.0.tgz",
-      "integrity": "sha512-j2/kt/PGbxvfeEm1uiRLlttZkQdn3hFe1rMr/wm3qFnMXSIw0Nmqu79k+TIoSj+KOwO98Sz9TbuNHU7ejv7IZA==",
-      "requires": {
-        "@types/dompurify": "^2.1.0",
-        "dompurify": "^2.2.7",
-        "jsdom": "^16.5.2"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        }
-      }
-    },
-    "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
-      "requires": {
-        "abab": "^2.0.5",
-        "acorn": "^8.2.4",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.1",
-        "domexception": "^2.0.1",
-        "escodegen": "^2.0.0",
-        "form-data": "^3.0.0",
-        "html-encoding-sniffer": "^2.0.1",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^6.1.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
-        "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-          "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w=="
-        }
-      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2503,27 +2040,11 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "json-pointer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
-      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
-      "requires": {
-        "foreach": "^2.0.4"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-      "requires": {
-        "code-error-fragment": "0.0.230",
-        "grapheme-splitter": "^1.0.4"
-      }
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json5": {
       "version": "1.0.1",
@@ -2539,15 +2060,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -2579,12 +2091,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2647,11 +2155,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.1.tgz",
-      "integrity": "sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -2710,19 +2213,6 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
-      }
-    },
-    "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-    },
-    "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "requires": {
-        "mime-db": "1.48.0"
       }
     },
     "minimalistic-assert": {
@@ -2864,11 +2354,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -2914,11 +2399,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "optional": true
-    },
-    "nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3001,28 +2481,6 @@
         "wrappy": "1"
       }
     },
-    "openapi-sampler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.1.tgz",
-      "integrity": "sha512-qBjxkSLJV183zTTs4fgxtU/iWSLUUu2aH2+5ddWkNhV7p8CSe/mnAgoLkEbMfHtel6yr9NF+vjUWqfM+iiwORQ==",
-      "requires": {
-        "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
-      }
-    },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      }
-    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -3088,11 +2546,6 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
-    },
-    "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -3172,11 +2625,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3210,11 +2658,6 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -3274,7 +2717,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -3399,11 +2843,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -3500,15 +2939,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-      "requires": {
-        "xmlchars": "^2.2.0"
-      }
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "scheduler": {
       "version": "0.19.1",
@@ -3770,11 +3202,6 @@
         "extend-shallow": "^3.0.0"
       }
     },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -3882,11 +3309,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -3956,11 +3378,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-merge-patch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
-      "integrity": "sha1-Lo3tGcVuoV29OtTtXbHI5a1UTDw="
-    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -4009,24 +3426,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      }
-    },
-    "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
-    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4044,14 +3443,6 @@
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -4088,11 +3479,6 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -4145,6 +3531,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4178,14 +3565,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "use-resize-observer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-7.0.0.tgz",
-      "integrity": "sha512-+RjrQsk/mL8aKy4TGBDiPkUv6whyeoGDMIZYk0gOGHOlnrsjImC+jG6lfAFcBCKAG9epGRL419adhDNdkDCQkA==",
-      "requires": {
-        "resize-observer-polyfill": "^1.5.1"
-      }
     },
     "util": {
       "version": "0.11.1",
@@ -4227,22 +3606,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
-    },
-    "w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "requires": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "w3c-xmlserializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
-      "requires": {
-        "xml-name-validator": "^3.0.0"
-      }
     },
     "watchpack": {
       "version": "1.7.4",
@@ -4380,11 +3743,6 @@
       "resolved": "https://registry.npmjs.org/web-react-components/-/web-react-components-1.4.2.tgz",
       "integrity": "sha512-//n/7TFHJHSrfDKguLN3kdJHDezQJpStwU6b751up6Nsax5Ry+GpRHsxmpc+BO2TarzakTxLwowvmWiyIbBHbw=="
     },
-    "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
-    },
     "webpack": {
       "version": "4.44.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
@@ -4488,29 +3846,6 @@
         }
       }
     },
-    "whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "requires": {
-        "iconv-lite": "0.4.24"
-      }
-    },
-    "whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-    },
-    "whatwg-url": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
-      "requires": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4525,11 +3860,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -4557,21 +3887,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw=="
-    },
-    "xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-    },
-    "xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -4589,11 +3904,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
     "yargs": {
       "version": "13.3.2",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Add to all TailwindCSS classes the `aui-` prefix. Why? More info is in Resolves https://github.com/asyncapi/asyncapi-react/issues/369:

> In the next version of component we use the TailwindCSS for styling. We don't use the prefixes for TailwindCSS classes used inside the component. It can ends with duplicated classes with other properties than ours in some application - in other words, users can attach to application existing TailwindCSS stylings based on "normal" TailwindCSS class names, so they can override our styles or our styles can override other.

**Related issue(s)**
Resolves https://github.com/asyncapi/asyncapi-react/issues/369
Blocked by https://github.com/asyncapi/asyncapi-react/pull/374
