### PR TITLE
feat: enable rendering of extensions on channel level

### DIFF
--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -107,6 +107,14 @@ export const Operation: React.FunctionComponent<Props> = ({
           </div>
         )}
 
+        {channel.hasBindings() && (
+          <div className="mt-2">
+            <Bindings name="Channel Bindings" bindings={channel.bindings()} />
+          </div>
+        )}
+
+        <Extensions name="Channel Extensions" item={channel} />
+
         {operation.hasBindings() && (
           <div className="mt-2">
             <Bindings
@@ -115,13 +123,8 @@ export const Operation: React.FunctionComponent<Props> = ({
             />
           </div>
         )}
-        {channel.hasBindings() && (
-          <div className="mt-2">
-            <Bindings name="Channel Bindings" bindings={channel.bindings()} />
-          </div>
-        )}
 
-        <Extensions item={operation} />
+        <Extensions name="Operation Extensions" item={operation} />
 
         {operation.hasTags() && (
           <div className="mt-2">

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -135,6 +135,8 @@ servers:
 
 channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+    x-security:
+      $ref: '#/components/securitySchemes/supportedOauthFlows/flows/clientCredentials'
     description: The topic on which measured values may be produced and consumed.
     parameters:
       streetlightId:


### PR DESCRIPTION
- enable rendering of extensions on channel item object
- change order of rendering where channel is first before operation as channel is a higher level object
- extended dummy https://github.com/asyncapi/generator/pull/613