### PR TITLE
fix: show only schemas and messages from components

### DIFF
--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -7,10 +7,11 @@ import { CommonHelpers } from '../../helpers';
 import { MESSAGES_TEXT } from '../../constants';
 
 export const Messages: React.FunctionComponent = () => {
-  const messages = useSpec().allMessages();
+  const asyncapi = useSpec();
   const config = useConfig();
+  const messages = asyncapi.hasComponents() && asyncapi.components().messages();
 
-  if (!messages.size) {
+  if (!messages || Object.keys(messages).length === 0) {
     return null;
   }
 
@@ -23,7 +24,7 @@ export const Messages: React.FunctionComponent = () => {
         {MESSAGES_TEXT}
       </h2>
       <ul>
-        {Array.from(messages).map(([messageName, message], idx) => (
+        {Object.entries(messages).map(([messageName, message], idx) => (
           <li
             className="mb-4"
             key={messageName}

--- a/library/src/containers/Schemas/Schemas.tsx
+++ b/library/src/containers/Schemas/Schemas.tsx
@@ -7,10 +7,11 @@ import { CommonHelpers } from '../../helpers';
 import { SCHEMAS_TEXT } from '../../constants';
 
 export const Schemas: React.FunctionComponent = () => {
-  const schemas = useSpec().allSchemas();
+  const asyncapi = useSpec();
   const config = useConfig();
+  const schemas = asyncapi.hasComponents() && asyncapi.components().schemas();
 
-  if (!schemas.size) {
+  if (!schemas || Object.keys(schemas).length === 0) {
     return null;
   }
 
@@ -23,7 +24,7 @@ export const Schemas: React.FunctionComponent = () => {
         {SCHEMAS_TEXT}
       </h2>
       <ul>
-        {Array.from(schemas).map(([schemaName, schema]) => (
+        {Object.entries(schemas).map(([schemaName, schema]) => (
           <li
             className="mb-4"
             key={schemaName}

--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -24,8 +24,9 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
 
   const info = asyncapi.info();
   const logo = info.ext('x-logo');
-  const allMessages = asyncapi.allMessages();
-  const allSchemas = asyncapi.allSchemas();
+  const components = asyncapi.hasComponents() && asyncapi.components();
+  const messages = components && components.messages();
+  const schemas = components && components.schemas();
 
   let Operations = OperationsList;
   if (showOperations === 'bySpecTags') {
@@ -34,7 +35,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
     Operations = OperationsByOperationsTags;
   }
 
-  const messagesList = allMessages.size > 0 && (
+  const messagesList = Object.keys(messages).length > 0 && (
     <li className="mb-3 mt-9">
       <a
         className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
@@ -44,7 +45,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
         Messages
       </a>
       <ul className="text-sm mt-2">
-        {Array.from(allMessages.keys()).map(messageName => (
+        {Object.keys(messages).map(messageName => (
           <li key={messageName}>
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
@@ -59,7 +60,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
     </li>
   );
 
-  const schemasList = allSchemas.size > 0 && (
+  const schemasList = Object.keys(schemas).length > 0 && (
     <li className="mb-3 mt-9">
       <a
         className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
@@ -69,7 +70,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
         Schemas
       </a>
       <ul className="text-sm mt-2">
-        {Array.from(allSchemas.keys()).map(schemaName => (
+        {Object.keys(schemas).map(schemaName => (
           <li key={schemaName}>
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Show only schemas and messages from components, not as currently, all schemas and messages.

**Related issue(s)**
Resolves https://github.com/asyncapi/html-template/issues/239
