### PR TITLE
fix: point to appropriate message in sidebar

### DIFF
--- a/library/src/components/Markdown.tsx
+++ b/library/src/components/Markdown.tsx
@@ -13,7 +13,7 @@ export const Markdown: React.FunctionComponent = ({ children }) => {
 
   return (
     <div
-      className="prose max-w-full text-sm"
+      className="prose max-w-none text-sm"
       dangerouslySetInnerHTML={{ __html: sanitize(renderMarkdown(children)) }}
     />
   );

--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -235,7 +235,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                     {schema.examples().map((e, idx) => (
                       <li
                         key={idx}
-                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2"
+                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2 break-all"
                       >
                         <span>{SchemaHelpers.prettifyValue(e)}</span>
                       </li>

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -20,12 +20,14 @@ import {
 
 interface Props {
   message: MessageType;
+  messageName?: string;
   index?: number | string;
   showExamples?: boolean;
 }
 
 export const Message: React.FunctionComponent<Props> = ({
   message,
+  messageName,
   index,
   showExamples = false,
 }) => {
@@ -35,7 +37,6 @@ export const Message: React.FunctionComponent<Props> = ({
     return null;
   }
 
-  const messageName = message.uid();
   const title = message.title();
   const summary = message.summary();
   const payload = message.payload();
@@ -56,7 +57,7 @@ export const Message: React.FunctionComponent<Props> = ({
             )}
             {title && <span className="text-gray-700 mr-2">{title}</span>}
             <span className="border text-orange-600 rounded text-xs py-0 px-2">
-              {messageName}
+              {message.uid()}
             </span>
           </div>
 
@@ -113,10 +114,14 @@ export const Message: React.FunctionComponent<Props> = ({
           {payload && (
             <div
               className="mt-2"
-              id={CommonHelpers.getIdentifier(
-                `message-${messageName}-payload`,
-                config,
-              )}
+              id={
+                messageName
+                  ? CommonHelpers.getIdentifier(
+                      `message-${messageName}-payload`,
+                      config,
+                    )
+                  : undefined
+              }
             >
               <Schema schemaName="Payload" schema={payload} />
             </div>
@@ -124,10 +129,14 @@ export const Message: React.FunctionComponent<Props> = ({
           {headers && (
             <div
               className="mt-2"
-              id={CommonHelpers.getIdentifier(
-                `message-${messageName}-headers`,
-                config,
-              )}
+              id={
+                messageName
+                  ? CommonHelpers.getIdentifier(
+                      `message-${messageName}-headers`,
+                      config,
+                    )
+                  : undefined
+              }
             >
               <Schema schemaName="Headers" schema={headers} />
             </div>

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -28,10 +28,7 @@ export const Messages: React.FunctionComponent = () => {
           <li
             className="mb-4"
             key={messageName}
-            id={`${CommonHelpers.getIdentifier(
-              `message-${messageName}`,
-              config,
-            )}`}
+            id={CommonHelpers.getIdentifier(`message-${messageName}`, config)}
           >
             <Message
               messageName={messageName}

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -29,11 +29,16 @@ export const Messages: React.FunctionComponent = () => {
             className="mb-4"
             key={messageName}
             id={`${CommonHelpers.getIdentifier(
-              `message-${message.uid()}`,
+              `message-${messageName}`,
               config,
             )}`}
           >
-            <Message message={message} index={idx + 1} key={messageName} />
+            <Message
+              messageName={messageName}
+              message={message}
+              index={idx + 1}
+              key={messageName}
+            />
           </li>
         ))}
       </ul>

--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
     Operations = OperationsByOperationsTags;
   }
 
-  const messagesList = Object.keys(messages).length > 0 && (
+  const messagesList = messages && Object.keys(messages).length > 0 && (
     <li className="mb-3 mt-9">
       <a
         className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
@@ -45,14 +45,14 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
         Messages
       </a>
       <ul className="text-sm mt-2">
-        {Object.keys(messages).map(messageName => (
+        {Object.entries(messages).map(([messageName, message]) => (
           <li key={messageName}>
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
               href={`#message-${messageName}`}
               onClick={() => setShowSidebar(false)}
             >
-              <div className="break-all inline-block">{messageName}</div>
+              <div className="break-all inline-block">{message.uid()}</div>
             </a>
           </li>
         ))}
@@ -60,11 +60,11 @@ export const Sidebar: React.FunctionComponent<Props> = ({ config }) => {
     </li>
   );
 
-  const schemasList = Object.keys(schemas).length > 0 && (
+  const schemasList = schemas && Object.keys(schemas).length > 0 && (
     <li className="mb-3 mt-9">
       <a
         className="text-xs uppercase text-gray-700 mt-10 mb-4 font-thin hover:text-gray-900"
-        href="#messages"
+        href="#schemas"
         onClick={() => setShowSidebar(false)}
       >
         Schemas

--- a/library/src/styles/default.css
+++ b/library/src/styles/default.css
@@ -67,4 +67,8 @@
   .container\:xl .panel--right {
     @apply hidden;
   }
+
+  .prose pre {
+    @apply whitespace-pre-wrap;
+  }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Point to appropriate message in sidebar - use message name, not message uid,
- Fix href in the sidebar navigation for the `schemas`
- Render the `uid` from message as message's name in the sidebar
- Break long string content in the message's examples and schema's examples