### PR TITLE
fix: add styles to sideEffects

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -39,7 +39,10 @@
     "./README.md",
     "./LICENSE"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./style/default.css",
+    "./style/default.min.css"
+  ],
   "scripts": {
     "start": "tsc -p tsconfig.esm.json --watch",
     "build:dev": "npm run build:esm && npm run build:types && npm run build:styles",

--- a/library/package.json
+++ b/library/package.json
@@ -40,8 +40,8 @@
     "./LICENSE"
   ],
   "sideEffects": [
-    "./style/default.css",
-    "./style/default.min.css"
+    "./styles/default.css",
+    "./styles/default.min.css"
   ],
   "scripts": {
     "start": "tsc -p tsconfig.esm.json --watch",

--- a/package.json
+++ b/package.json
@@ -105,5 +105,9 @@
       ],
       "@semantic-release/github"
     ]
-  }
+  },
+  "sideEffects": [
+    "./style/default.css",
+    "./style/default.min.css"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -105,9 +105,5 @@
       ],
       "@semantic-release/github"
     ]
-  },
-  "sideEffects": [
-    "./style/default.css",
-    "./style/default.min.css"
-  ]
+  }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make `styles/*` excluded from webpack tree shaking using `sideEffects` in `package.json`


**Related issue(s)**

When imported the styles should cause side effects, but because the current release (I am using `1.0.0-next.15`) has `"sideEffects": false,` in `package.json`, webpack tree shakes the `import '@asyncapi/react-component/styles/default.css';` at build time.

A workaround for us it's using `require` instead of `import` just for this specific file but I rather fix the root issue than mixing require/import. 

I have tested locally and works as expected. I am open to different approaches if you thought of one, but according to webpack docs, `sideEffects` should be used exactly for this situation, let me know your thoughts! 