### PR TITLE
fix: make fallback for 2.2.0 channel.servers field

### DIFF
--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -37,7 +37,7 @@ export const Operation: React.FunctionComponent<Props> = ({
 
   const operationId = operation.id();
   const externalDocs = operation.externalDocs();
-  // check typeof as fallback for older version that `2.2.0`
+  // check typeof as fallback for older version than `2.2.0`
   const servers = typeof channel.servers === 'function' && channel.servers();
 
   const operationSummary = operation.summary();

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -31,13 +31,14 @@ export const Operation: React.FunctionComponent<Props> = ({
 }) => {
   const config = useConfig();
 
-  if (!operation) {
+  if (!operation || !channel) {
     return null;
   }
 
   const operationId = operation.id();
   const externalDocs = operation.externalDocs();
-  const servers = channel.servers();
+  // check typeof as fallback for older version that `2.2.0`
+  const servers = typeof channel.servers === 'function' && channel.servers();
 
   const operationSummary = operation.summary();
   const parameters = SchemaHelpers.parametersToSchema(channel.parameters());
@@ -101,7 +102,7 @@ export const Operation: React.FunctionComponent<Props> = ({
           </div>
         )}
 
-        {servers.length > 0 ? (
+        {servers && servers.length > 0 ? (
           <div className="mt-2 text-sm">
             <p>Available only on servers:</p>
             <ul className="flex flex-wrap leading-normal">


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

More info https://github.com/asyncapi/html-template/issues/264

Make fallback for new in `2.2.0` AsyncAPI version `channel.servers' field - support case when someone will use newest component with old generator, which isn't support `2.2.0` version of AsyncAPI.

**Related issue(s)**
Fixes https://github.com/asyncapi/html-template/issues/264
