### PR TITLE
fix: render empty extensions and bindings

### DIFF
--- a/library/src/components/Bindings.tsx
+++ b/library/src/components/Bindings.tsx
@@ -29,7 +29,9 @@ export const Bindings: React.FunctionComponent<Props> = ({
         </div>
       );
       return (
-        <Schema schemaName={schemaName} schema={schema} key={bindingName} />
+        schema && (
+          <Schema schemaName={schemaName} schema={schema} key={bindingName} />
+        )
       );
     },
   );

--- a/library/src/components/Extensions.tsx
+++ b/library/src/components/Extensions.tsx
@@ -20,8 +20,10 @@ export const Extensions: React.FunctionComponent<Props> = ({
 
   const schema = SchemaHelpers.jsonToSchema(extensions);
   return (
-    <div className="mt-2">
-      <Schema schemaName={name} schema={schema} />
-    </div>
+    schema && (
+      <div className="mt-2">
+        <Schema schemaName={name} schema={schema} />
+      </div>
+    )
   );
 };

--- a/library/src/components/__tests__/Bindings.test.tsx
+++ b/library/src/components/__tests__/Bindings.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Bindings } from '../Bindings';
+
+describe('Bindings component', () => {
+  test('should work with simple data', async () => {
+    const bindings = {
+      mqtt: {
+        fooMqtt: 'barMqtt',
+      },
+      kafka: {
+        fooKafka: 'barKafka',
+      },
+    };
+    render(<Bindings bindings={bindings} />);
+
+    expect(screen.getAllByText('Binding specific information')).toBeDefined();
+    expect(screen.getAllByText('Binding specific information')).toHaveLength(2);
+    expect(screen.getByText('mqtt')).toBeDefined();
+    expect(screen.getByText('fooMqtt')).toBeDefined();
+    expect(screen.getByText('barMqtt')).toBeDefined();
+    expect(screen.getByText('kafka')).toBeDefined();
+    expect(screen.getByText('fooKafka')).toBeDefined();
+    expect(screen.getByText('barKafka')).toBeDefined();
+  });
+
+  test('should render empty binding as string', async () => {
+    const bindings = {
+      mqtt: {
+        foo: 'bar',
+      },
+      kafka: undefined,
+      http: null,
+    };
+    render(<Bindings bindings={bindings} />);
+
+    expect(screen.getAllByText('Binding specific information')).toBeDefined();
+    expect(screen.getAllByText('Binding specific information')).toHaveLength(3);
+    expect(screen.getByText('mqtt')).toBeDefined();
+    expect(screen.getByText('foo')).toBeDefined();
+    expect(screen.getByText('bar')).toBeDefined();
+    expect(screen.getByText('kafka')).toBeDefined();
+    expect(screen.getByText('http')).toBeDefined();
+    expect(screen.queryByText('undefined')).toEqual(null);
+    expect(screen.queryByText('null')).toEqual(null);
+  });
+});

--- a/library/src/components/__tests__/Extensions.test.tsx
+++ b/library/src/components/__tests__/Extensions.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// @ts-ignore
+import SchemaModel from '@asyncapi/parser/lib/models/schema';
+
+import { Extensions } from '../Extensions';
+
+describe('Extensions component', () => {
+  test('should work with simple data', async () => {
+    const schema = {
+      'x-foo': 'xBar',
+      'x-bar': 'xFoo',
+    };
+    const schemaModel = new SchemaModel(schema);
+    render(<Extensions item={schemaModel} />);
+
+    expect(screen.getByText('Extensions')).toBeDefined();
+    expect(screen.getByText('x-foo')).toBeDefined();
+    expect(screen.getByText('xBar')).toBeDefined();
+    expect(screen.getByText('x-bar')).toBeDefined();
+    expect(screen.getByText('xFoo')).toBeDefined();
+  });
+
+  test('should filter non extensions', async () => {
+    const schema = {
+      foo: {
+        foo: 'bar',
+      },
+      bar: {
+        foo: 'bar',
+      },
+      'x-foo': 'xBar',
+      'x-bar': 'xFoo',
+    };
+    const schemaModel = new SchemaModel(schema);
+    render(<Extensions item={schemaModel} />);
+
+    expect(screen.getByText('Extensions')).toBeDefined();
+    expect(screen.getByText('x-foo')).toBeDefined();
+    expect(screen.getByText('xBar')).toBeDefined();
+    expect(screen.getByText('x-bar')).toBeDefined();
+    expect(screen.getByText('xFoo')).toBeDefined();
+    expect(screen.queryByText('foo')).toEqual(null);
+    expect(screen.queryByText('bar')).toEqual(null);
+  });
+
+  test('should render empty extension as string', async () => {
+    const schema = {
+      'x-foo': 'xBar',
+      'x-bar': undefined,
+      'x-foobar': null,
+    };
+    const schemaModel = new SchemaModel(schema);
+    render(<Extensions item={schemaModel} />);
+
+    expect(screen.getByText('Extensions')).toBeDefined();
+    expect(screen.getByText('x-foo')).toBeDefined();
+    expect(screen.getByText('xBar')).toBeDefined();
+    expect(screen.getByText('x-bar')).toBeDefined();
+    expect(screen.getByText('x-foobar')).toBeDefined();
+    expect(screen.queryByText('undefined')).toEqual(null);
+    expect(screen.queryByText('null')).toEqual(null);
+  });
+});

--- a/library/src/helpers/__tests__/schema.test.ts
+++ b/library/src/helpers/__tests__/schema.test.ts
@@ -508,18 +508,35 @@ describe('SchemaHelpers', () => {
       expect(result).toEqual(schema);
     });
 
-    test('should transform boolean to schema', () => {
-      const json = true;
+    test('should transform array to schema', () => {
+      const json = ['bar', 2137, true];
       const schema = new Schema({
-        type: 'string',
-        const: 'true',
-        'x-schema-private-raw-value': true,
+        type: 'array',
+        items: [
+          {
+            type: 'string',
+            const: 'bar',
+            'x-schema-private-raw-value': true,
+          },
+          {
+            type: 'string',
+            const: '2137',
+            'x-schema-private-raw-value': true,
+          },
+          {
+            type: 'string',
+            const: 'true',
+            'x-schema-private-raw-value': true,
+          },
+        ],
+        'x-schema-private-render-additional-info': false,
+        'x-schema-private-render-type': false,
       });
       const result = SchemaHelpers.jsonToSchema(json);
       expect(result).toEqual(schema);
     });
 
-    test('should transform boolean to schema', () => {
+    test('should transform object to schema', () => {
       const json = {
         bar: 'foo',
       };

--- a/library/src/helpers/__tests__/schema.test.ts
+++ b/library/src/helpers/__tests__/schema.test.ts
@@ -474,6 +474,135 @@ describe('SchemaHelpers', () => {
     });
   });
 
+  describe('.jsonToSchema', () => {
+    test('should transform string to schema', () => {
+      const json = 'foobar';
+      const schema = new Schema({
+        type: 'string',
+        const: 'foobar',
+        'x-schema-private-raw-value': true,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should transform number to schema', () => {
+      const json = 2137;
+      const schema = new Schema({
+        type: 'string',
+        const: '2137',
+        'x-schema-private-raw-value': true,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should transform boolean to schema', () => {
+      const json = true;
+      const schema = new Schema({
+        type: 'string',
+        const: 'true',
+        'x-schema-private-raw-value': true,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should transform boolean to schema', () => {
+      const json = true;
+      const schema = new Schema({
+        type: 'string',
+        const: 'true',
+        'x-schema-private-raw-value': true,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should transform boolean to schema', () => {
+      const json = {
+        bar: 'foo',
+      };
+      const schema = new Schema({
+        type: 'object',
+        properties: {
+          bar: {
+            type: 'string',
+            const: 'foo',
+            'x-schema-private-raw-value': true,
+          },
+        },
+        'x-schema-private-render-additional-info': false,
+        'x-schema-private-render-type': false,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should transform complex data to schema', () => {
+      const json = {
+        foo: ['bar', 2137, true],
+        bar: 'foo',
+      };
+      const schema = new Schema({
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'array',
+            items: [
+              {
+                type: 'string',
+                const: 'bar',
+                'x-schema-private-raw-value': true,
+              },
+              {
+                type: 'string',
+                const: '2137',
+                'x-schema-private-raw-value': true,
+              },
+              {
+                type: 'string',
+                const: 'true',
+                'x-schema-private-raw-value': true,
+              },
+            ],
+            'x-schema-private-render-additional-info': false,
+            'x-schema-private-render-type': false,
+          },
+          bar: {
+            type: 'string',
+            const: 'foo',
+            'x-schema-private-raw-value': true,
+          },
+        },
+        'x-schema-private-render-additional-info': false,
+        'x-schema-private-render-type': false,
+      });
+      const result = SchemaHelpers.jsonToSchema(json);
+      expect(result).toEqual(schema);
+    });
+
+    test('should return empty string when data is null', () => {
+      const result = SchemaHelpers.jsonToSchema(null);
+      const schema = new Schema({
+        type: 'string',
+        const: '',
+        'x-schema-private-raw-value': true,
+      });
+      expect(result).toEqual(schema);
+    });
+
+    test('should return empty string when data is undefined', () => {
+      const result = SchemaHelpers.jsonToSchema(undefined);
+      const schema = new Schema({
+        type: 'string',
+        const: '',
+        'x-schema-private-raw-value': true,
+      });
+      expect(result).toEqual(schema);
+    });
+  });
+
   describe('.getCustomExtensions', () => {
     test('should return extensions', () => {
       const schema = new Schema({

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -241,7 +241,7 @@ export class SchemaHelpers {
     return new SchemaClass(json);
   }
 
-  static jsonToSchema(value: any): any {
+  static jsonToSchema(value: any): SchemaClass {
     const json = this.jsonFieldToSchema(value);
     return new SchemaClass(json);
   }
@@ -478,6 +478,13 @@ export class SchemaHelpers {
   }
 
   private static jsonFieldToSchema(value: any): any {
+    if (value === undefined || value === null) {
+      return {
+        type: 'string',
+        const: '',
+        [this.extRawValue]: true,
+      };
+    }
     if (typeof value !== 'object') {
       const str =
         typeof value.toString === 'function' ? value.toString() : value;

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -132,6 +132,9 @@ servers:
     variables:
       port:
         default: '9092'
+    bindings:
+      dupa: 
+        lol: string
 
 channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -132,9 +132,6 @@ servers:
     variables:
       port:
         default: '9092'
-    bindings:
-      dupa: 
-        lol: string
 
 channels:
   smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Render empty extensions and bindings:
- improve `jsonFieldToSchema` function to handle `null` and `undefined` values.
- add unit tests for helper and also for `Bindings` and `Extensions` component

**Related issue(s)**
Resolves https://github.com/asyncapi/studio/issues/221
