### PR TITLE
feat: add collapse button for nested subschemas in the Schema component

### DIFF
--- a/library/src/components/CollapseButton.tsx
+++ b/library/src/components/CollapseButton.tsx
@@ -12,16 +12,52 @@ export const CollapseButton: React.FunctionComponent<Props> = ({
   <button {...rest} className={`focus:outline-none ${rest.className}`}>
     {children}
     <svg
-      version="1.1"
-      viewBox="0 0 24 24"
-      x="0"
       xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      stroke="currentColor"
+      version="1.1"
+      x="0"
       y="0"
+      fill="none"
       {...chevronProps}
-      className={`inline-block align-baseline cursor-pointer -mb-1 w-5 transform transition-transform duration-150 ease-linear ${chevronProps?.className ||
+      className={`inline-block align-baseline cursor-pointer -mb-1 ml-1 w-3.5 h-3.5 transform transition-transform duration-150 ease-linear ${chevronProps?.className ||
         ''}`}
     >
-      <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 " />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  </button>
+);
+
+export const DoubleCollapseButton: React.FunctionComponent<Props> = ({
+  chevronProps,
+  children,
+  ...rest
+}) => (
+  <button {...rest} className={`focus:outline-none ${rest.className}`}>
+    {children}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      stroke="currentColor"
+      version="1.1"
+      x="0"
+      y="0"
+      fill="none"
+      {...chevronProps}
+      className={`inline-block align-baseline cursor-pointer -mb-1 ml-1 w-3.5 h-3.5 transform transition-transform duration-150 ease-linear ${chevronProps?.className ||
+        ''}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 13l-7 7-7-7m14-8l-7 7-7-7"
+      />
     </svg>
   </button>
 );

--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -1,7 +1,13 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Schema as SchemaType } from '@asyncapi/parser';
 
-import { Href, CollapseButton, Markdown, Extensions } from './index';
+import {
+  Href,
+  CollapseButton,
+  DoubleCollapseButton,
+  Markdown,
+  Extensions,
+} from './index';
 import { SchemaHelpers } from '../helpers';
 
 interface Props {
@@ -16,7 +22,10 @@ interface Props {
   onlyTitle?: boolean;
 }
 
-const SchemaContext = React.createContext({ reverse: false });
+const SchemaContext = React.createContext({
+  reverse: false,
+  deepExpanded: false,
+});
 
 export const Schema: React.FunctionComponent<Props> = ({
   schemaName,
@@ -29,8 +38,17 @@ export const Schema: React.FunctionComponent<Props> = ({
   expanded = false,
   onlyTitle = false,
 }) => {
-  const { reverse } = useContext(SchemaContext);
+  const { reverse, deepExpanded } = useContext(SchemaContext);
+  const [deepExpand, setDeepExpand] = useState(false);
   const [expand, setExpand] = useState(expanded);
+
+  useEffect(() => {
+    setDeepExpand(deepExpanded);
+  }, [deepExpanded, setDeepExpand]);
+
+  useEffect(() => {
+    setExpand(deepExpand);
+  }, [deepExpand, setExpand]);
 
   if (
     !schema ||
@@ -100,19 +118,32 @@ export const Schema: React.FunctionComponent<Props> = ({
     );
 
   return (
-    <SchemaContext.Provider value={{ reverse: !reverse }}>
+    <SchemaContext.Provider
+      value={{ reverse: !reverse, deepExpanded: deepExpand }}
+    >
       <div>
         <div className="flex py-2">
           <div className={`${onlyTitle ? '' : 'min-w-1/4'} mr-2`}>
             {isExpandable && !isCircular ? (
-              <CollapseButton
-                onClick={() => setExpand(prev => !prev)}
-                chevronProps={{
-                  className: expand ? '-rotate-180' : '-rotate-90',
-                }}
-              >
-                {renderedSchemaName}
-              </CollapseButton>
+              <>
+                <CollapseButton
+                  onClick={() => setExpand(prev => !prev)}
+                  chevronProps={{
+                    className: expand ? '-rotate-180' : '-rotate-90',
+                  }}
+                >
+                  {renderedSchemaName}
+                </CollapseButton>
+                <DoubleCollapseButton
+                  onClick={() => setDeepExpand(prev => !prev)}
+                  className="ml-2"
+                  chevronProps={{
+                    className: `${
+                      deepExpand ? '-rotate-180' : '-rotate-90'
+                    } -ml-2`,
+                  }}
+                />
+              </>
             ) : (
               <span
                 className={`break-words text-sm ${isProperty ? 'italic' : ''}`}

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -57,9 +57,7 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
         <CollapseButton
           onClick={() => setExpand(prev => !prev)}
           chevronProps={{
-            className: `fill-current text-gray-200 ${
-              expand ? '-rotate-180' : '-rotate-90'
-            }`,
+            className: `text-gray-200 ${expand ? '-rotate-180' : '-rotate-90'}`,
           }}
         >
           <span className="px-2 py-1 mr-2 text-gray-200 text-sm border rounded focus:outline-none">


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Add collapse button for nested subschemas in the Schema component. Button is next to the normal collapse button. If the user presses the extra button, all subschemas will open/close (depending if subschemas are opened/closed).

**Related issue(s)**
Resolves #440
