### PR TITLE
chore: replace @github-actions[bot] with @asyncapi-bot-eve

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the "@asyncapi/asyncapi-react" repository. The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @magicmatatjahu @derberg @fmvilas @github-actions[bot]
+* @magicmatatjahu @derberg @fmvilas @asyncapi-bot-eve


### PR DESCRIPTION
**Description**

This PR fixes the `CODEOWNERS` file where `@github-actions[bot]` was being added as Code Owner. This is not currently possible, as we noticed recently thanks to GH which added lining to the `CODEOWNERS` file.
Instead, `@asyncapi-bot-eve` user has been created for this purpose and now is being added into the `CODEOWNERS` file thanks to this PR.

**Related issue(s)**
https://github.com/asyncapi/community/issues/275