### PR TITLE
fix: updated openapi-sampler to resolve security vulnerability CVE-20…

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -16,7 +16,7 @@
         "dompurify": "^2.1.1",
         "markdown-it": "^12.3.2",
         "merge": "^2.1.0",
-        "openapi-sampler": "1.0.0",
+        "openapi-sampler": "1.2.1",
         "react-use": "^12.2.0"
       },
       "devDependencies": {
@@ -3546,9 +3546,9 @@
       "dev": true
     },
     "node_modules/json-pointer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
-      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
       "dependencies": {
         "foreach": "^2.0.4"
       }
@@ -4245,12 +4245,12 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0.tgz",
-      "integrity": "sha512-HysKj4ZuLk0RpZkopao5SIupUX8LMOTsEDTw9dSzcRv6BBW6Ep1IdbKwYsCrYM9tnw4VZtebR/N5sJHY6qqRew==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
+      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
+        "json-pointer": "0.6.2"
       }
     },
     "node_modules/optionator": {
@@ -9218,9 +9218,9 @@
       "dev": true
     },
     "json-pointer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
-      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
       "requires": {
         "foreach": "^2.0.4"
       }
@@ -9796,12 +9796,12 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0.tgz",
-      "integrity": "sha512-HysKj4ZuLk0RpZkopao5SIupUX8LMOTsEDTw9dSzcRv6BBW6Ep1IdbKwYsCrYM9tnw4VZtebR/N5sJHY6qqRew==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
+      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
+        "json-pointer": "0.6.2"
       }
     },
     "optionator": {

--- a/library/package.json
+++ b/library/package.json
@@ -53,7 +53,7 @@
     "dompurify": "^2.1.1",
     "markdown-it": "^12.3.2",
     "merge": "^2.1.0",
-    "openapi-sampler": "1.0.0",
+    "openapi-sampler": "1.2.1",
     "react-use": "^12.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…21-23820

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

`json-pointer@0.6.1`, which is currently a dependency of `openapi-sampler`, is causing a "moderate" dependency alert (see https://github.com/advisories/GHSA-v5vg-g7rq-363w). 

Changes proposed in this pull request:

- Updates `openapi-sampler` to a more recent version that uses a version of json-pointer that has [resolved this issue](https://github.com/manuelstofer/json-pointer/commit/47dae1d369a25bd9bdcdbc963b8699b89a882c81). 

**Related issue(s)**
See https://github.com/manuelstofer/json-pointer/issues/35
