### PR TITLE
fix: add fallback for null parameter's schema

### DIFF
--- a/library/src/helpers/__tests__/schema.test.ts
+++ b/library/src/helpers/__tests__/schema.test.ts
@@ -443,7 +443,7 @@ describe('SchemaHelpers', () => {
 
   describe('.parametersToSchema', () => {
     test('should transform parameters to schema', () => {
-      const variables = {
+      const parameters = {
         foo: new ChannelParameter({ schema: { type: 'string' } }),
         bar: new ChannelParameter({
           schema: { type: 'string' },
@@ -469,7 +469,36 @@ describe('SchemaHelpers', () => {
         'x-schema-private-render-additional-info': false,
         'x-schema-private-render-type': false,
       });
-      const result = SchemaHelpers.parametersToSchema(variables);
+      const result = SchemaHelpers.parametersToSchema(parameters);
+      expect(result).toEqual(schema);
+    });
+
+    test('should handle empty schema of parameter', () => {
+      const parameters = {
+        foo: new ChannelParameter({
+          description: 'Some description',
+        }),
+        bar: new ChannelParameter({
+          location: '$message.payload#/user/id',
+        }),
+      };
+      const schema = new Schema({
+        type: 'object',
+        properties: {
+          foo: {
+            description: 'Some description',
+            'x-schema-private-parameter-location': undefined,
+          },
+          bar: {
+            description: undefined,
+            'x-schema-private-parameter-location': '$message.payload#/user/id',
+          },
+        },
+        required: ['foo', 'bar'],
+        'x-schema-private-render-additional-info': false,
+        'x-schema-private-render-type': false,
+      });
+      const result = SchemaHelpers.parametersToSchema(parameters);
       expect(result).toEqual(schema);
     });
   });

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -203,11 +203,14 @@ export class SchemaHelpers {
 
     const json = {
       type: 'object',
-      properties: Object.entries(urlVariables).reduce((obj, [urlName, url]) => {
-        obj[urlName] = Object.assign({}, url.json());
-        obj[urlName].type = 'string';
-        return obj;
-      }, {}),
+      properties: Object.entries(urlVariables).reduce(
+        (obj, [variableName, variable]) => {
+          obj[variableName] = Object.assign({}, variable.json() || {});
+          obj[variableName].type = 'string';
+          return obj;
+        },
+        {},
+      ),
       required: Object.keys(urlVariables),
       [this.extRenderType]: false,
       [this.extRenderAdditionalInfo]: false,
@@ -226,7 +229,11 @@ export class SchemaHelpers {
       type: 'object',
       properties: Object.entries(parameters).reduce(
         (obj, [paramaterName, parameter]) => {
-          obj[paramaterName] = Object.assign({}, parameter.schema().json());
+          const parameterSchema = parameter.schema();
+          obj[paramaterName] = Object.assign(
+            {},
+            parameterSchema ? parameterSchema.json() : {},
+          );
           obj[paramaterName].description =
             parameter.description() || obj[paramaterName].description;
           obj[paramaterName][this.extParameterLocation] = parameter.location();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Check if channel parameter's `schema` is null/undefined and then use fallback for that values. Add unit tests for fix.

**Related issue(s)**
See https://github.com/asyncapi/studio/issues/309
See https://github.com/asyncapi/studio/discussions/326
