### PR TITLE
fix: define react and react-dom as peerDependencies

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -77,6 +77,10 @@
     "openapi-sampler": "^1.2.1",
     "use-resize-observer": "^8.0.0"
   },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.9.0",
     "@tailwindcss/typography": "^0.4.0",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

We use `react` and `react-dom` in component, but we don't have defined these packages as peer-dependencies and e.g. yarn throw error due to this fact. See more #609 

I tested package installing new project with yarn without and with `react/react-dom` deps and yarn in first case throw errors, in second installation passed.

**Related issue(s)**
Resolves #609 
