### PR TITLE
feat: add deep collapse button in schema component

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -16,6 +16,7 @@
         "isomorphic-dompurify": "^0.13.0",
         "marked": "^4.0.14",
         "openapi-sampler": "^1.2.1",
+        "react-icons": "^4.4.0",
         "use-resize-observer": "^8.0.0"
       },
       "devDependencies": {
@@ -12419,6 +12420,14 @@
       },
       "peerDependencies": {
         "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -26058,6 +26067,12 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
       }
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/library/package.json
+++ b/library/package.json
@@ -75,6 +75,7 @@
     "isomorphic-dompurify": "^0.13.0",
     "marked": "^4.0.14",
     "openapi-sampler": "^1.2.1",
+    "react-icons": "^4.4.0",
     "use-resize-observer": "^8.0.0"
   },
   "devDependencies": {

--- a/library/src/components/CollapseButton.tsx
+++ b/library/src/components/CollapseButton.tsx
@@ -1,27 +1,28 @@
 import React, { ButtonHTMLAttributes, SVGAttributes } from 'react';
+import { HiChevronRight } from 'react-icons/hi';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   chevronProps?: SVGAttributes<SVGElement>;
+  expanded?: boolean;
 }
 
 export const CollapseButton: React.FunctionComponent<Props> = ({
   chevronProps,
+  expanded = false,
   children,
   ...rest
 }) => (
-  <button {...rest} className={`focus:outline-none ${rest.className}`}>
-    {children}
-    <svg
-      version="1.1"
-      viewBox="0 0 24 24"
-      x="0"
-      xmlns="http://www.w3.org/2000/svg"
-      y="0"
+  <button
+    {...rest}
+    className={`focus:outline-none ${rest.className}`}
+    type="button"
+  >
+    <div className="inline-block">{children}</div>
+    <HiChevronRight
       {...chevronProps}
-      className={`inline-block align-baseline cursor-pointer -mb-1 w-5 transform transition-transform duration-150 ease-linear ${chevronProps?.className ||
-        ''}`}
-    >
-      <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 " />
-    </svg>
+      className={`inline-block align-baseline cursor-pointer ml-0.5 -mb-1 w-5 h-5 transform transition-transform duration-150 ease-linear ${
+        expanded ? '-rotate-90' : ''
+      } ${chevronProps?.className || ''}`}
+    />
   </button>
 );

--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Schema as SchemaType } from '@asyncapi/parser';
 
 import { Href, CollapseButton, Markdown, Extensions } from './index';
@@ -16,7 +16,10 @@ interface Props {
   onlyTitle?: boolean;
 }
 
-const SchemaContext = React.createContext({ reverse: false });
+const SchemaContext = React.createContext({
+  reverse: false,
+  deepExpanded: false,
+});
 
 export const Schema: React.FunctionComponent<Props> = ({
   schemaName,
@@ -26,11 +29,20 @@ export const Schema: React.FunctionComponent<Props> = ({
   isProperty = false,
   isCircular = false,
   dependentRequired,
-  expanded = false,
+  expanded: propExpanded = false,
   onlyTitle = false,
 }) => {
-  const { reverse } = useContext(SchemaContext);
-  const [expand, setExpand] = useState(expanded);
+  const { reverse, deepExpanded } = useContext(SchemaContext);
+  const [expanded, setExpanded] = useState(propExpanded);
+  const [deepExpand, setDeepExpand] = useState(false);
+
+  useEffect(() => {
+    setDeepExpand(deepExpanded);
+  }, [deepExpanded, setDeepExpand]);
+
+  useEffect(() => {
+    setExpanded(deepExpand);
+  }, [deepExpand, setExpanded]);
 
   if (
     !schema ||
@@ -57,7 +69,7 @@ export const Schema: React.FunctionComponent<Props> = ({
     schema.isCircular() ||
     schema.ext('x-parser-circular') ||
     false;
-  let uid = schema.uid();
+  const uid = schema.uid();
 
   const schemaItems = schema.items();
   if (schemaItems && !Array.isArray(schemaItems)) {
@@ -73,7 +85,6 @@ export const Schema: React.FunctionComponent<Props> = ({
       schemaItems.isCircular() ||
       schemaItems.ext('x-parser-circular') ||
       false;
-    uid = schemaItems.uid();
     if (
       isCircular &&
       typeof (schemaItems as any).circularSchema === 'function'
@@ -100,19 +111,28 @@ export const Schema: React.FunctionComponent<Props> = ({
     );
 
   return (
-    <SchemaContext.Provider value={{ reverse: !reverse }}>
+    <SchemaContext.Provider
+      value={{ reverse: !reverse, deepExpanded: deepExpand }}
+    >
       <div>
         <div className="flex py-2">
           <div className={`${onlyTitle ? '' : 'min-w-1/4'} mr-2`}>
             {isExpandable && !isCircular ? (
-              <CollapseButton
-                onClick={() => setExpand(prev => !prev)}
-                chevronProps={{
-                  className: expand ? '-rotate-180' : '-rotate-90',
-                }}
-              >
-                {renderedSchemaName}
-              </CollapseButton>
+              <>
+                <CollapseButton
+                  onClick={() => setExpanded(prev => !prev)}
+                  expanded={expanded}
+                >
+                  {renderedSchemaName}
+                </CollapseButton>
+                <button
+                  type="button"
+                  onClick={() => setDeepExpand(prev => !prev)}
+                  className="ml-1 text-sm text-gray-500"
+                >
+                  {deepExpand ? 'Collapse all' : 'Expand all'}
+                </button>
+              </>
             ) : (
               <span
                 className={`break-words text-sm ${isProperty ? 'italic' : ''}`}
@@ -275,7 +295,7 @@ export const Schema: React.FunctionComponent<Props> = ({
           <div
             className={`rounded p-4 py-2 border bg-gray-100 ${
               reverse ? 'bg-gray-200' : ''
-            } ${expand ? 'block' : 'hidden'}`}
+            } ${expanded ? 'block' : 'hidden'}`}
           >
             <SchemaProperties schema={schema} />
             <SchemaItems schema={schema} />

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -49,25 +49,24 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
   schema,
   examples = [],
 }) => {
-  const [expand, setExpand] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <div className="mt-4">
       <div>
         <CollapseButton
-          onClick={() => setExpand(prev => !prev)}
+          onClick={() => setExpanded(prev => !prev)}
+          expanded={expanded}
           chevronProps={{
-            className: `fill-current text-gray-200 ${
-              expand ? '-rotate-180' : '-rotate-90'
-            }`,
+            className: 'fill-current text-gray-200',
           }}
         >
-          <span className="px-2 py-1 mr-2 text-gray-200 text-sm border rounded focus:outline-none">
+          <span className="inline-block w-20 py-0.5 mr-1 text-gray-200 text-sm border text-center rounded focus:outline-none">
             {type}
           </span>
         </CollapseButton>
       </div>
-      <div className={expand ? 'block' : 'hidden'}>
+      <div className={expanded ? 'block' : 'hidden'}>
         {examples && examples.length > 0 ? (
           <ul>
             {examples.map((example, idx) => (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
  
Add collapse button for nested subschemas in the Schema component:

  ![image](https://user-images.githubusercontent.com/20404945/171183077-268710d4-8db4-4ab9-bc84-e1e88f72a580.png)
  ![image](https://user-images.githubusercontent.com/20404945/171183199-83c15d60-4259-4294-b309-bde259d411b4.png)
  
Fix `uid` for array schemas (wrong uid appears in some cases).

**Related issue(s)**
Resolves #440
Resolves #605 

Gitpod url (you need to login by github accout): https://gitpod.io/#https://github.com/asyncapi/asyncapi-react/pull/620, wait for installing deps and open `3000` port (you should see notification for that).

cc @mcturco @derberg 