### PR TITLE
docs: update the command to install the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A official [React](https://reactjs.org/) component for AsyncAPI 2.0 specificatio
 
 <!-- toc -->
 
+- [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Using in React](#using-in-react)
@@ -27,9 +28,9 @@ A official [React](https://reactjs.org/) component for AsyncAPI 2.0 specificatio
 - [Props](#props)
 - [Features](#features)
 - [Styles](#styles)
-  * [Default styles](#default-styles)
-  * [Custom styles](#custom-styles)
-  * [Custom logo](#custom-logo)
+  - [Default styles](#default-styles)
+  - [Custom styles](#custom-styles)
+  - [Custom logo](#custom-logo)
 - [Playground](#playground)
 - [Modules](#modules)
 - [Development](#development)
@@ -48,7 +49,7 @@ A official [React](https://reactjs.org/) component for AsyncAPI 2.0 specificatio
 Run this command to install the component in your project:
 
 ```sh
-npm install --save @asyncapi/react-component
+npm install --save @asyncapi/react-component@next
 ```
 
 Check out this simple sandbox application that uses the React component:

--- a/docs/usage/angular.md
+++ b/docs/usage/angular.md
@@ -12,7 +12,7 @@ If you wanna use the React AsyncAPI component in your Angular project, you have 
 First read the [Readme](../../Readme.md) document and install the React AsyncAPI component by:
 
 ```sh
-npm install --save @asyncapi/react-component
+npm install --save @asyncapi/react-component@next
 ```
 
 ### Usage

--- a/docs/usage/nextjs.md
+++ b/docs/usage/nextjs.md
@@ -7,7 +7,7 @@ Read the document to find out how to use React AsyncAPI component in the NextJS 
 First read the [Readme](../../Readme.md) document and install the React AsyncAPI component by:
 
 ```sh
-npm install --save @asyncapi/react-component
+npm install --save @asyncapi/react-component@next
 ```
 
 ## Usage without SSR/SSG (dynamic documentation)

--- a/docs/usage/standalone-bundle.md
+++ b/docs/usage/standalone-bundle.md
@@ -7,7 +7,7 @@ If you are not using React you may want to use the Standalone Bundle of AsyncAPI
 Run this command to install the component in your project:
 
 ```sh
-npm install --save @asyncapi/react-component
+npm install --save @asyncapi/react-component@next
 ```
 
 ## Usage in frameworks

--- a/docs/usage/vue.md
+++ b/docs/usage/vue.md
@@ -7,7 +7,7 @@ If you wanna use the React AsyncAPI component in your Vue project, you may want 
 First read the [Readme](../../Readme.md) document and install the React AsyncAPI component by:
 
 ```sh
-npm install --save @asyncapi/react-component
+npm install --save @asyncapi/react-component@next
 ```
 
 ## Usage

--- a/docs/usage/web-component.md
+++ b/docs/usage/web-component.md
@@ -7,7 +7,7 @@ If you are not using React you may want to use the `@asyncapi/web-component` com
 Run this command to install the component in your project:
 
 ```sh
-npm install --save @asyncapi/web-component
+npm install --save @asyncapi/web-component@next
 ```
 
 Check out this simple sandbox application that uses the Web Component in Angular project:


### PR DESCRIPTION
I was using the original command npm install --save @asyncapi/react-component when doing research for my article and I had some issues which were resolved but only when I requested senior dev to look at it.

It is more likely due to my inexperience but there are other junior developers like myself who may not know to use npm install --save @asyncapi/react-component@next command.

To make juniors life easier, may I ask to merge this request into your branch?

Thank you.