### PR TITLE
feat: add config options to override pub sub label text

### DIFF
--- a/docs/configuration/config-modification.md
+++ b/docs/configuration/config-modification.md
@@ -24,6 +24,8 @@ interface ConfigInterface {
     showOperations?: 'byDefault' | 'bySpecTags' | 'byOperationsTags';
   },
   parserOptions?: ParserOptions;
+  publishLabel?: string;
+  subscribeLabel?: string;
 }
 ```
 
@@ -46,6 +48,16 @@ interface ConfigInterface {
 
   This field contains configuration for [`asyncapi-parser`](https://github.com/asyncapi/parser). See available options [here](https://github.com/asyncapi/parser-js/blob/master/API.md#module_@asyncapi/parser..parse).
   This field is set to `null` by default.
+
+- **publishLabel?: string**
+
+  This field contains configuration responsible for customizing the "PUB" label for operations.
+  This field is set to `PUB` by default.
+
+- **subscribeLabel?: string**
+
+  This field contains configuration responsible for customizing the "SUB" label for operations.
+  This field is set to `SUB` by default.
 
 ## Examples
 
@@ -118,5 +130,7 @@ In the above examples, after concatenation with the default configuration, the r
   sidebar: {
     showOperations: 'bySpecTags',
   },
+  publishLabel: 'PUB',
+  subscribeLabel: 'SUB',
 }
 ```

--- a/docs/configuration/config-modification.md
+++ b/docs/configuration/config-modification.md
@@ -51,12 +51,12 @@ interface ConfigInterface {
 
 - **publishLabel?: string**
 
-  This field contains configuration responsible for customizing the "PUB" label for operations.
+  This field contains configuration responsible for customizing the label for publish operations.
   This field is set to `PUB` by default.
 
 - **subscribeLabel?: string**
 
-  This field contains configuration responsible for customizing the "SUB" label for operations.
+  This field contains configuration responsible for customizing the label for subscribe operations.
   This field is set to `SUB` by default.
 
 ## Examples

--- a/library/src/config/config.ts
+++ b/library/src/config/config.ts
@@ -3,6 +3,8 @@ export interface ConfigInterface {
   show?: ShowConfig;
   sidebar?: SideBarConfig;
   parserOptions?: any;
+  publishLabel?: string;
+  subscribeLabel?: string;
 }
 
 export interface ShowConfig {

--- a/library/src/config/default.ts
+++ b/library/src/config/default.ts
@@ -1,4 +1,8 @@
 import { ConfigInterface } from './config';
+import {
+  PUBLISH_LABEL_DEFAULT_TEXT,
+  SUBSCRIBE_LABEL_DEFAULT_TEXT,
+} from '../constants';
 
 export const defaultConfig: ConfigInterface = {
   schemaID: '',
@@ -14,4 +18,6 @@ export const defaultConfig: ConfigInterface = {
   sidebar: {
     showOperations: 'byOperationsTags',
   },
+  publishLabel: PUBLISH_LABEL_DEFAULT_TEXT,
+  subscribeLabel: SUBSCRIBE_LABEL_DEFAULT_TEXT,
 };

--- a/library/src/constants.ts
+++ b/library/src/constants.ts
@@ -35,7 +35,9 @@ export const SPECIFICATION_TEXT = 'Specification';
 
 export const DEPRECATED_TEXT = 'Deprecated';
 export const PUBLISH_TEXT = 'Publish';
+export const PUBLISH_LABEL_DEFAULT_TEXT = 'PUB';
 export const SUBSCRIBE_TEXT = 'Subscribe';
+export const SUBSCRIBE_LABEL_DEFAULT_TEXT = 'SUB';
 export const REQUIRED_TEXT = 'Required';
 export const GENERATED_TEXT = 'Generated';
 

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -14,7 +14,11 @@ import {
 
 import { useConfig } from '../../contexts';
 import { CommonHelpers, SchemaHelpers } from '../../helpers';
-import { EXTERAL_DOCUMENTATION_TEXT } from '../../constants';
+import {
+  EXTERAL_DOCUMENTATION_TEXT,
+  PUBLISH_LABEL_DEFAULT_TEXT,
+  SUBSCRIBE_LABEL_DEFAULT_TEXT,
+} from '../../constants';
 import { PayloadType } from '../../types';
 
 interface Props {
@@ -185,8 +189,8 @@ export const OperationInfo: React.FunctionComponent<Props> = ({
             title={type}
           >
             {type === PayloadType.PUBLISH
-              ? config.publishLabel || 'PUB'
-              : config.subscribeLabel || 'SUB'}
+              ? config.publishLabel || PUBLISH_LABEL_DEFAULT_TEXT
+              : config.subscribeLabel || SUBSCRIBE_LABEL_DEFAULT_TEXT}
           </span>{' '}
           <span className="font-mono text-base">{channelName}</span>
         </h3>

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -167,6 +167,7 @@ export const OperationInfo: React.FunctionComponent<Props> = ({
   channelName,
   channel,
 }) => {
+  const config = useConfig();
   const operationSummary = operation.summary();
   const externalDocs = operation.externalDocs();
   const operationId = operation.id();
@@ -183,7 +184,9 @@ export const OperationInfo: React.FunctionComponent<Props> = ({
             }`}
             title={type}
           >
-            {type === PayloadType.PUBLISH ? 'PUB' : 'SUB'}
+            {type === PayloadType.PUBLISH
+              ? config.publishLabel || 'PUB'
+              : config.subscribeLabel || 'SUB'}
           </span>{' '}
           <span className="font-mono text-base">{channelName}</span>
         </h3>

--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -3,8 +3,12 @@ import { Tag } from '@asyncapi/parser';
 
 import { CollapseButton } from '../../components';
 import { SideBarConfig } from '../../config/config';
-import { useSpec } from '../../contexts';
+import { useConfig, useSpec } from '../../contexts';
 import { SpecificationHelpers } from '../../helpers';
+import {
+  PUBLISH_LABEL_DEFAULT_TEXT,
+  SUBSCRIBE_LABEL_DEFAULT_TEXT,
+} from '../../constants';
 
 const SidebarContext = React.createContext<{
   setShowSidebar: React.Dispatch<React.SetStateAction<boolean>>;
@@ -418,6 +422,7 @@ interface OperationsPubItemProps {
 const OperationsPubItem: React.FunctionComponent<OperationsPubItemProps> = ({
   channelName,
 }) => {
+  const config = useConfig();
   const { setShowSidebar } = useContext(SidebarContext);
 
   return (
@@ -431,7 +436,7 @@ const OperationsPubItem: React.FunctionComponent<OperationsPubItemProps> = ({
           className="bg-blue-600 font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded text-xs"
           title="Publish"
         >
-          Pub
+          {config.publishLabel || PUBLISH_LABEL_DEFAULT_TEXT}
         </span>
         <span className="break-all inline-block">{channelName}</span>
       </a>
@@ -442,6 +447,7 @@ const OperationsPubItem: React.FunctionComponent<OperationsPubItemProps> = ({
 const OperationsSubItem: React.FunctionComponent<OperationsPubItemProps> = ({
   channelName,
 }) => {
+  const config = useConfig();
   const { setShowSidebar } = useContext(SidebarContext);
 
   return (
@@ -455,7 +461,7 @@ const OperationsSubItem: React.FunctionComponent<OperationsPubItemProps> = ({
           className="bg-green-600 font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded text-xs"
           title="Subscribe"
         >
-          SUB
+          {config.subscribeLabel || SUBSCRIBE_LABEL_DEFAULT_TEXT}
         </span>
         <span className="break-all inline-block">{channelName}</span>
       </a>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:webcomponent": "cd web-component && npm run prepare",
     "build:playground": "cd playground && npm run build",
     "lint": "tslint -c ./tslint.json --project tsconfig.base.json --format verbose && prettier --check \"**/*.{ts,tsx,js,jsx,json,html,css,yaml}\"",
-    "lint:fix": "tslint -c ./tslint.json --project tsconfig.base.json --format verbose --fix && prettier --write '**/*.{ts,tsx,js,jsx,json,html,css,yaml}'",
+    "lint:fix": "tslint -c ./tslint.json --project tsconfig.base.json --format verbose --fix && prettier --write \"**/*.{ts,tsx,js,jsx,json,html,css,yaml}\"",
     "conflict-check": "tslint-config-prettier-check ./tslint.json",
     "markdownlint": "markdownlint **/*.md",
     "release": "semantic-release",


### PR DESCRIPTION
Updated documentation. All tests pass. Not sure how I would go about adding new tests for this feature...

**Description**

Changes proposed in this pull request:

- Provide two new config properties for overriding the default "PUB" and "SUB" operation label text.

**Reason for feature**

At my company, Megh Computing Inc, we are using AsyncAPI to document our WebSocket API. Our API does not operate in a typical PUB-SUB way; clients do not "publish" data to the endpoints. Any data sent to an endpoint is to configure that WebSocket session and specify the async events that the client wishes to receive. We have received feedback from our customers that the terminology label "PUB" is confusing. Our solution is to rename the "PUB" label to "CONF", but the tool currently does not support overriding that label text.