### PR TITLE
feat: add support for mermaid diagrams in markdown

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -74,6 +74,7 @@
     "highlight.js": "^10.7.2",
     "isomorphic-dompurify": "^0.13.0",
     "marked": "^4.0.14",
+    "mermaid": "^9.3.0",
     "openapi-sampler": "^1.2.1",
     "use-resize-observer": "^8.0.0"
   },

--- a/library/src/helpers/marked.ts
+++ b/library/src/helpers/marked.ts
@@ -15,7 +15,7 @@ hljs.registerLanguage('yaml', yaml);
 import bash from 'highlight.js/lib/languages/bash';
 hljs.registerLanguage('bash', bash);
 
-const markedOptions: marked.MarkedOptions = {
+const codeHighlightOptions: marked.MarkedOptions = {
   langPrefix: 'hljs language-',
   highlight: (code, language) => {
     if (!hljs.getLanguage(language)) {
@@ -28,9 +28,30 @@ const markedOptions: marked.MarkedOptions = {
     }
   },
 };
+const codeHighlightRenderer = new marked.Renderer(codeHighlightOptions);
+const markdownRenderer = new marked.Renderer();
+markdownRenderer.code = (code, language, isEscaped) => {
+  if (language === 'mermaid') {
+    addMermaidIfNeeded();
+    return '<pre class="mermaid">' + code + '</pre>';
+  }
+  return codeHighlightRenderer.code(code, language, isEscaped);
+};
+
+let gotMermaidAlready = false;
+function addMermaidIfNeeded() {
+  if (gotMermaidAlready) {
+    return;
+  }
+  gotMermaidAlready = true;
+  const script = document.createElement('script');
+  script.type = 'module';
+  script.text = `import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';`;
+  document.body.appendChild(script);
+}
 
 export function renderMarkdown(content: string): string {
-  return marked(content, markedOptions);
+  return marked(content, { renderer: markdownRenderer });
 }
 
 export { hljs };

--- a/library/src/helpers/marked.ts
+++ b/library/src/helpers/marked.ts
@@ -1,4 +1,5 @@
 import { marked } from 'marked';
+import { initializeMermaidOnce }  from './mermaid';
 
 // @ts-ignore
 import hljs from 'highlight.js/lib/core';
@@ -32,23 +33,11 @@ const codeHighlightRenderer = new marked.Renderer(codeHighlightOptions);
 const markdownRenderer = new marked.Renderer();
 markdownRenderer.code = (code, language, isEscaped) => {
   if (language === 'mermaid') {
-    addMermaidIfNeeded();
+    initializeMermaidOnce();
     return '<pre class="mermaid">' + code + '</pre>';
   }
   return codeHighlightRenderer.code(code, language, isEscaped);
 };
-
-let gotMermaidAlready = false;
-function addMermaidIfNeeded() {
-  if (gotMermaidAlready) {
-    return;
-  }
-  gotMermaidAlready = true;
-  const script = document.createElement('script');
-  script.type = 'module';
-  script.text = `import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';`;
-  document.body.appendChild(script);
-}
 
 export function renderMarkdown(content: string): string {
   return marked(content, { renderer: markdownRenderer });

--- a/library/src/helpers/mermaid.ts
+++ b/library/src/helpers/mermaid.ts
@@ -1,0 +1,16 @@
+import mermaid from 'mermaid';
+
+var mermaidInitialized = false;
+export function initializeMermaidOnce() {
+  if (mermaidInitialized) {
+    return;
+  }
+  mermaidInitialized = true;
+
+  // This breaks the build for some reason 🤷‍♂️
+  // Here's the super-useful error that truly makes sense:
+  // Can't reexport the named export 'o' from non EcmaScript module (only default export is available)
+  mermaid.initialize({
+    startOnLoad: true,
+  });
+}

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -12,6 +12,15 @@ info:
     * Dim a specific streetlight 😎
     * Receive real-time information about environmental lighting conditions 📈
 
+    ### We got mermaids 🧜‍♀️
+
+    \`\`\`mermaid
+    graph LR
+      Mermaid --> Graph --> Looks --> Cool
+      Graph --> Works["Works!"]
+      Works --> Cool
+    \`\`\`
+
   termsOfService: http://asyncapi.org/terms/
   contact:
     name: API Support


### PR DESCRIPTION
**Description**

This change adds support to include mermaid diagrams directly in any markdown.

**Related issue(s)**

Fixes #712
