### PR TITLE
chore: Set Access-Control-Allow-Origin header for playground devserver

### DIFF
--- a/playground/config-overrides.js
+++ b/playground/config-overrides.js
@@ -1,9 +1,19 @@
 const path = require('path');
 
-module.exports = function override(config, env) {
-  config.resolve = Object.assign({}, config.resolve, {
-    modules: [path.resolve(__dirname, 'node_modules'), 'node_modules'],
-  });
+module.exports = {
+  webpack: function override(config, env) {
+    config.resolve = Object.assign({}, config.resolve, {
+      modules: [path.resolve(__dirname, 'node_modules'), 'node_modules'],
+    });
 
-  return config;
+    return config;
+  },
+  devServer: function(configFunction) {
+    return function(proxy, allowedHost) {
+      const config = configFunction(proxy, allowedHost);
+      config.headers = { 'Access-Control-Allow-Origin': '*' };
+
+      return config;
+    };
+  },
 };


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Set "Access-Control-Allow-Origin" header for playground dev server to "*" to allow playground to fetch an external schema from somewhere other than same origin when running it locally.

![image](https://github.com/asyncapi/asyncapi-react/assets/9197140/10fb7aac-dd3a-4207-95fa-023541e21c53)
(Trying to load schema from `http://localhost:8090/docs/asyncapi.json` with playground devserver running on `http://localhost:3000` for example)

**Related issue(s)**
