### PR TITLE
fix: change schema name word breaking to anywhere

### DIFF
--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -103,7 +103,7 @@ export const Schema: React.FunctionComponent<Props> = ({
   const styledSchemaName = isProperty ? 'italic' : '';
   const renderedSchemaName =
     typeof schemaName === 'string' ? (
-      <span className={`break-words text-sm ${styledSchemaName}`}>
+      <span className={`break-anywhere text-sm ${styledSchemaName}`}>
         {schemaName}
       </span>
     ) : (
@@ -135,7 +135,9 @@ export const Schema: React.FunctionComponent<Props> = ({
               </>
             ) : (
               <span
-                className={`break-words text-sm ${isProperty ? 'italic' : ''}`}
+                className={`break-anywhere text-sm ${
+                  isProperty ? 'italic' : ''
+                }`}
               >
                 {schemaName}
               </span>

--- a/library/src/styles/default.css
+++ b/library/src/styles/default.css
@@ -72,3 +72,9 @@
     @apply whitespace-pre-wrap;
   }
 }
+
+@layer utilities {
+  .break-anywhere {
+    overflow-wrap: anywhere;
+  }
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Change schema name style word breaking to use [`overflow-wrap: anywhere`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#anywhere) to prevent content going under the sidebar when using long schema names that cannot be broken up into words.

**Why is this an issue?**
When using long names for schemas that cannot be broken up into words like when using Java package names, the content can go under the sidebar.
This makes the content unreadable to a large extent unless the window is made small enough for the sidebar to be put inside the burger menu.

When applying `overflow-wrap: anywhere` the browser will still try to wrap on words but also allows breaking up long, otherwise unbreakable strings to avoid overflowing.

**Example**

Previously:
![Screenshot_20230728_173042](https://github.com/asyncapi/asyncapi-react/assets/9197140/fbdc63fa-a384-4d59-9b1b-d832d25151a2)

Afterwards:
![Screenshot_20230728_173104](https://github.com/asyncapi/asyncapi-react/assets/9197140/f0bbf690-9e76-4046-a5b6-97f6adb72d24)

<details>
<summary>AsyncApi definition used for the example:</summary>

```json
{
  "asyncapi": "2.4.0",
  "info": {
    "title": "Example API",
    "version": "0.1.0",
    "description": "An API for demonstration purposes"
  },
  "channels": {
    "exchange/my.routingkey": {
      "bindings": {
        "amqp": {
          "is": "routingKey",
          "queue": {
            "name": "my.routingkey"
          },
          "exchange": {
            "name": "exchange",
            "type": "topic"
          }
        }
      },
      "subscribe": {
        "description": "Informs about an example to be considered",
        "message": {
          "$ref": "#/components/messages/com.example.myapp.infrastructure._shared.messaging.dto.ExampleMessage"
        }
      }
    }
  },
  "components": {
    "messages": {
      "com.example.myapp.infrastructure._shared.messaging.dto.ExampleMessage": {
        "name": "Example message",
        "payload": {
          "type": "object",
          "properties": {
            "metadata": {
              "$ref": "#/components/schemas/com.example.myapp.infrastructure._shared.messaging.dto.SomeDtoClassThatIsUsedInsideAMessage"
            }
          }
        }
      }
    },
    "schemas": {
      "com.example.myapp.infrastructure._shared.messaging.dto.SomeDtoClassThatIsUsedInsideAMessage": {
        "name": "Example schema",
        "type": "object",
        "properties": {
          "testProperty": {
            "type": "string"
          }
        }
      }
    }
  }
}
```

</details>

**Related issue(s)**
