### PR TITLE
feat: use schema's title when available in `{one,any,all}Of` applicators

### DIFF
--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -280,7 +280,12 @@ export const Schema: React.FunctionComponent<Props> = ({
                   <Schema
                     key={idx}
                     schema={s}
-                    schemaName={idx === 0 ? 'Adheres to:' : 'Or to:'}
+                    schemaName={SchemaHelpers.applicatorSchemaName(
+                      idx,
+                      'Adheres to',
+                      'Or to',
+                      s.title(),
+                    )}
                   />
                 ))}
             {schema.anyOf() &&
@@ -290,7 +295,12 @@ export const Schema: React.FunctionComponent<Props> = ({
                   <Schema
                     key={idx}
                     schema={s}
-                    schemaName={idx === 0 ? 'Can adhere to:' : 'Or to:'}
+                    schemaName={SchemaHelpers.applicatorSchemaName(
+                      idx,
+                      'Can adhere to',
+                      'Or to',
+                      s.title(),
+                    )}
                   />
                 ))}
             {schema.allOf() &&
@@ -300,7 +310,12 @@ export const Schema: React.FunctionComponent<Props> = ({
                   <Schema
                     key={idx}
                     schema={s}
-                    schemaName={idx === 0 ? 'Consists of:' : 'And with:'}
+                    schemaName={SchemaHelpers.applicatorSchemaName(
+                      idx,
+                      'Consists of',
+                      'And of',
+                      s.title(),
+                    )}
                   />
                 ))}
             {schema.not() && (

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -101,6 +101,20 @@ export class SchemaHelpers {
     return type;
   }
 
+  static applicatorSchemaName(
+    idx: number,
+    firstCase: string,
+    otherCases: string,
+    title?: string,
+  ) {
+    const suffix = (title !== null && ` ${title}:`) || `:`;
+    if (idx === 0) {
+      return `${firstCase}${suffix}`;
+    } else {
+      return `${otherCases}${suffix}`;
+    }
+  }
+
   static prettifyValue(value: any, strict = true): string {
     const typeOf = typeof value;
     if (typeOf === 'string') {

--- a/playground/src/specs/streetlights.ts
+++ b/playground/src/specs/streetlights.ts
@@ -400,6 +400,7 @@ components:
     union:
       type: [string, number]
     objectWithKey:
+      title: objectWithKey
       type: object
       propertyNames:
         format: email


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Applicators can be a little hard to navigate, especially on deeply nested schema. While the `uid` provides a nice middle-ground solution, it doesn't actually work when schemas are defined outside of the main specification and more importantly, it isn't necessarily meant to be human-readable. The `title` property however is meant just for that.

Changes proposed in this pull request:

- This PR does just that, it adds the `title` next to branches enumeration in `{one,any,all}Of` applicators. When not available, it defaults to the current behavior.

<img width="706" alt="image" src="https://github.com/asyncapi/asyncapi-react/assets/5680256/3159a8fb-b004-43f8-b42f-42321e65de99">

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

N/A
