### PR TITLE
ci: eject from global release config file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,5 +18,6 @@ plugins:
   - preset: conventionalcommits
 - - "@semantic-release/release-notes-generator"
   - preset: conventionalcommits
-- "@semantic-release/npm"
+- - "@semantic-release/npm"
+  - pkgRoot: library
 - "@semantic-release/github"


### PR DESCRIPTION
Release of 1.0 failed -> https://github.com/asyncapi/asyncapi-react/actions/runs/6322951494

We can use global generic release workflow, but not the config, cause of monorepo. 

`get-global-releaserc` topic already removed