### PR TITLE
fix: only render suffix in applicatorSchemaName if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ npm-debug.log*
 lerna-debug.log*
 /**/*.tgz
 /.idea/
+/.vscode/

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -107,7 +107,7 @@ export class SchemaHelpers {
     otherCases: string,
     title?: string,
   ) {
-    const suffix = (title !== null && ` ${title}:`) || `:`;
+    const suffix = title ? ` ${title}:` : `:`;
     if (idx === 0) {
       return `${firstCase}${suffix}`;
     } else {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- #744 introduced a bug when schemas don't include a title. It now renders "Consists of undefined:" and "And of undefined:". This fix makes sure the suffix is dropped when the title doesn't exist.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/asyncapi/asyncapi-react/pull/744/files#r1433826404