### PR TITLE
feat: append schema title to objects

### DIFF
--- a/library/src/helpers/__tests__/schema.test.ts
+++ b/library/src/helpers/__tests__/schema.test.ts
@@ -169,6 +169,12 @@ describe('SchemaHelpers', () => {
       const result = SchemaHelpers.toSchemaType(schema);
       expect(result).toEqual(`number | string | boolean`);
     });
+
+    test('should handle append title to object', () => {
+      const schema = new Schema({ type: 'object', title: 'SampleType' });
+      const result = SchemaHelpers.toSchemaType(schema);
+      expect(result).toEqual('object [SampleType]');
+    });
   });
 
   describe('.prettifyValue', () => {

--- a/library/src/helpers/schema.ts
+++ b/library/src/helpers/schema.ts
@@ -98,6 +98,10 @@ export class SchemaHelpers {
     if (combinedType) {
       return combinedType;
     }
+
+    if (type === 'object' && schema.title()) {
+      type += ' [' + schema.title() + ']';
+    }
     return type;
   }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- If a schema of type "object" is used, it is hard to guess the real type in complex big schemas
- Append the title of object make thinks easy to understand.

Visualization of change
![Snag_c3944c6](https://github.com/asyncapi/asyncapi-react/assets/512850/cfedeb08-98a7-485e-a171-11ed46b9fe16)

