### PR TITLE
fix: oneOf included when inside of arrays

### DIFF
--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -471,7 +471,7 @@ const SchemaItems: React.FunctionComponent<SchemaItemsProps> = ({ schema }) => {
     !Array.isArray(items) &&
     Object.keys(items.properties() || {}).length
   ) {
-    return <SchemaProperties schema={items} />;
+    return <Schema schema={items} />;
   } else if (Array.isArray(items)) {
     return (
       <>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- This fixes #926, but it creates a bad user experience by needing another click to expand it. How can it be automatically expanded? I tried to use the `expanded` prop, but that didn't work as expected.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #926