### PR TITLE
Issue 993 security refs

### DIFF
--- a/library/src/containers/Servers/Security.tsx
+++ b/library/src/containers/Servers/Security.tsx
@@ -6,7 +6,6 @@ import {
 } from '@asyncapi/parser';
 
 import { Href, Markdown } from '../../components';
-import { useSpec } from '../../contexts';
 import { ServerHelpers } from '../../helpers';
 
 interface Props {
@@ -20,32 +19,20 @@ export const Security: React.FunctionComponent<Props> = ({
   protocol = '',
   header = 'Security',
 }) => {
-  const asyncapi = useSpec();
-  const securitySchemes =
-    !asyncapi.components().isEmpty() && asyncapi.components().securitySchemes();
-
   let renderedSecurities;
-  if (
-    !security?.length ||
-    !securitySchemes ||
-    !Object.keys(securitySchemes).length
-  ) {
-    renderedSecurities = (
-      <SecurityItem
-        protocol={protocol}
-        securitySchema={
-          ['kafka', 'kafka-secure'].includes(protocol)
-            ? null
-            : security[0]?.all()[0].scheme()
-        }
-      />
-    );
+  if (!security?.length) {
+    if (protocol === 'kafka' || protocol === 'kafka-secure') {
+      renderedSecurities = (
+        <SecurityItem protocol={protocol} securitySchema={null} />
+      );
+    }
   } else {
     const securities: React.ReactNodeArray = Object.values(security)
-      .map(requirement => {
-        const requirements = requirement.all();
-        const def = requirements[0].scheme();
-        const requiredScopes = requirements[0].scopes();
+      .map(requirement => requirement.all())
+      .flat()
+      .map(requirements => {
+        const def = requirements.scheme();
+        const requiredScopes = requirements.scopes();
 
         if (!def) {
           return null;

--- a/library/src/containers/Servers/Security.tsx
+++ b/library/src/containers/Servers/Security.tsx
@@ -39,9 +39,8 @@ export const Security: React.FunctionComponent<Props> = ({
     const securities: React.ReactNodeArray = Object.values(security)
       .map(requirement => {
         const requirements = requirement.all();
-        const key = Object.keys(requirements)[0];
-        const def = securitySchemes[Number(key)];
-        const requiredScopes: any = requirements[Number(key)];
+        const def = requirements[0].scheme();
+        const requiredScopes = requirements[0].scopes();
 
         if (!def) {
           return null;

--- a/library/src/containers/Servers/Security.tsx
+++ b/library/src/containers/Servers/Security.tsx
@@ -30,11 +30,16 @@ export const Security: React.FunctionComponent<Props> = ({
     !securitySchemes ||
     !Object.keys(securitySchemes).length
   ) {
-    if (protocol === 'kafka' || protocol === 'kafka-secure') {
-      renderedSecurities = (
-        <SecurityItem protocol={protocol} securitySchema={null} />
-      );
-    }
+    renderedSecurities = (
+      <SecurityItem
+        protocol={protocol}
+        securitySchema={
+          ['kafka', 'kafka-secure'].includes(protocol)
+            ? null
+            : security[0].all()[0].scheme()
+        }
+      />
+    );
   } else {
     const securities: React.ReactNodeArray = Object.values(security)
       .map(requirement => {

--- a/library/src/containers/Servers/Security.tsx
+++ b/library/src/containers/Servers/Security.tsx
@@ -36,7 +36,7 @@ export const Security: React.FunctionComponent<Props> = ({
         securitySchema={
           ['kafka', 'kafka-secure'].includes(protocol)
             ? null
-            : security[0].all()[0].scheme()
+            : security[0]?.all()[0].scheme()
         }
       />
     );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Fixes #993 
Incorrect rendering of security schemas in AsyncAPI 3.0, by reference and inline.
See https://github.com/asyncapi/studio/issues/1066

Changes proposed in this pull request:

- The `security` property supplied to `Security` component seems to be enough to fix all issues:
  - Correctly pick security schema by reference
  - Supporting schemas written inline
- I also added support for multiple schemas (both by reference and inline).

Perhaps I didn't understand something, but without all those complications it seem to work well on all cases and the tests are passing. Anyway, consider it a proposal, feel free to make or request changes.

**Related issue(s)**

https://github.com/asyncapi/studio/issues/1066