### PR TITLE
feat: add configuration to always show message examples

### DIFF
--- a/docs/configuration/config-modification.md
+++ b/docs/configuration/config-modification.md
@@ -17,6 +17,7 @@ interface ConfigInterface {
     servers?: boolean;
     operations?: boolean;
     messages?: boolean;
+    messageExamples?: boolean;
     schemas?: boolean;
     errors?: boolean;
   };
@@ -45,7 +46,10 @@ interface ConfigInterface {
 - **show?: Partial<ShowConfig>**
 
   This field contains configuration responsible for rendering specific parts of the AsyncAPI component.
-  All except the `sidebar` fields are set to `true` by default.
+  The `sidebar` and `messageExamples` fields are set to `false` by default. The default for all other fields is `true`.
+
+  The examples for messages shown within an operation are always displayed. To also show examples for the
+  standalone messages in the "Messages" section, set `messageExamples` to `true`.
 
 - **sidebar?: Partial<SideBarConfig>**
 

--- a/library/src/config/config.ts
+++ b/library/src/config/config.ts
@@ -19,6 +19,7 @@ export interface ShowConfig {
   servers?: boolean;
   operations?: boolean;
   messages?: boolean;
+  messageExamples?: boolean;
   schemas?: boolean;
   errors?: boolean;
 }

--- a/library/src/config/default.ts
+++ b/library/src/config/default.ts
@@ -16,6 +16,7 @@ export const defaultConfig: ConfigInterface = {
     servers: true,
     operations: true,
     messages: true,
+    messageExamples: false,
     schemas: true,
     errors: true,
   },

--- a/library/src/containers/Messages/Messages.tsx
+++ b/library/src/containers/Messages/Messages.tsx
@@ -36,6 +36,7 @@ export const Messages: React.FunctionComponent = () => {
               message={message}
               index={idx + 1}
               key={message.id()}
+              showExamples={config?.show?.messageExamples ?? false}
             />
           </li>
         ))}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds a configuration `show.messageExamples`, which when `true` also shows examples for the messages in the `Messages` section (and not only for the messages in the "Operations" section).

**Background:**

Maybe we are using the AsyncAPI CLI not in the intended way. But we have messages that are not referenced in one of the operations, so that the examples for these messages are not visible. This PR is proposing to add a new configuration, which will show examples for the messages listed in the "Messages" section.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
