### PR TITLE
fix: remove code needed prior react 18 to fix release of webcomponent

### DIFF
--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -55,6 +55,15 @@ jobs:
           package: ./web-component/package.json
           access: public
           tag: github.event.release.target_commitish
+      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'Release of web component for AsyncAPI React failed'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
 
   playground:
     name: Release Playground
@@ -89,3 +98,12 @@ jobs:
           folder: playground/out
           git-config-name: asyncapi-bot
           git-config-email: info@asyncapi.io
+      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'Release of playground for AsyncAPI React failed'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}

--- a/playground/app/page.tsx
+++ b/playground/app/page.tsx
@@ -93,7 +93,6 @@ class Playground extends Component<unknown, State> {
             </Tabs>
           </CodeEditorsWrapper>
           <AsyncApiWrapper>
-            {/* @ts-expect-error remove when library and web-component is upgraded to React v18 */}
             <AsyncApi schema={schema} config={parsedConfig} />
           </AsyncApiWrapper>
         </SplitWrapper>

--- a/playground/components/CodeEditorComponent.tsx
+++ b/playground/components/CodeEditorComponent.tsx
@@ -33,7 +33,6 @@ class CodeEditorComponent extends Component<Props, State> {
 
     return (
       <CodeEditorWrapper>
-        {/* @ts-expect-error remove when library and web-component is upgraded to React v18 */}
         <CodeMirror
           value={code}
           basicSetup={{

--- a/playground/components/SplitWrapper.tsx
+++ b/playground/components/SplitWrapper.tsx
@@ -8,7 +8,6 @@ interface SplitWrapperProps {
 // react-split should be replaced with a React 18 friendly library or CSS
 const SplitWrapper = (props: SplitWrapperProps) => (
   <>
-    {/* @ts-expect-error upgrade React to v18 */}
     <Split
       style={{
         width: '100%',

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@asyncapi/react-component": "^1.4.10",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "web-react-components": "^1.4.2"
   },
   "devDependencies": {

--- a/web-component/webpack.config.js
+++ b/web-component/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
       // 2. You might be breaking the Rules of Hooks
       // 3. You might have more than one copy of React in the same app
       // See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem."
-      react: path.resolve('./node_modules/react'),
+      react: path.resolve('../node_modules/react'),
     },
     fallback: {
       fs: false,


### PR DESCRIPTION
webcomponent and playground releases were failing

https://github.com/asyncapi/asyncapi-react/actions/runs/9496432356/job/26170818500

I also added now slack notifications for failing releases as we had no idea and nobody explicitly wrote to us about it

I learned from https://github.com/asyncapi/asyncapi-react/pull/1016#issuecomment-2186453509