### PR TITLE
fix: update web-component bumping script for react

### DIFF
--- a/web-component/bump-react-comp.sh
+++ b/web-component/bump-react-comp.sh
@@ -9,5 +9,7 @@ echo "Log all versions of the package on npm registry"
 npm show @asyncapi/react-component versions
 echo "Log latest version of the package on npm registry"
 npm show @asyncapi/react-component dist-tags.latest
-echo "Starting installation"
+echo "We need to uninstall old version first to make sure package.json will get updated latest version number"
+npm uninstall @asyncapi/react-component
+echo "Starting installation of @asyncapi/react-component@$VERSION in $PWD"
 npm install @asyncapi/react-component@$VERSION --save --loglevel verbose


### PR DESCRIPTION
Looks like depending on npm versions there are different behaviours of installation

even though existing script has explicit `--save`, if some other script in the same run updated dependency to lates, and it is already in node_modules, installation of the same dependency with `--save` in another project in monorepo, will not result in updates in package.json

This this PR introduce initial remove of dependency and then fresh installation