### PR TITLE
bug: fixes the accessibility issue related to 'focus'

### DIFF
--- a/library/src/components/CollapseButton.tsx
+++ b/library/src/components/CollapseButton.tsx
@@ -33,7 +33,7 @@ export const CollapseButton: React.FunctionComponent<Props> = ({
 }) => (
   <button
     {...rest}
-    className={`focus:outline-none ${rest.className}`}
+    className={`focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${rest.className ?? ''}`}
     type="button"
   >
     <div className="inline-block">{children}</div>
@@ -45,3 +45,4 @@ export const CollapseButton: React.FunctionComponent<Props> = ({
     />
   </button>
 );
+


### PR DESCRIPTION
Fixes accessibility issue related to 'focus' by adding a custom focus ring for collapsible buttons.

**Description**



**Related issue(s)**
#961 
![focus_react_button](https://github.com/user-attachments/assets/848fec4a-7027-44cb-a299-174c9892c554)

