### PR TITLE
refactor: removing redundant use of undefined keyword, and A fragment with only one child is redundant.

### DIFF
--- a/library/src/helpers/__tests__/schema.test.ts
+++ b/library/src/helpers/__tests__/schema.test.ts
@@ -900,7 +900,6 @@ describe('SchemaHelpers', () => {
           0,
           FIRST_CASE,
           OTHER_CASES,
-          undefined,
         ),
       ).toMatchSnapshot();
 
@@ -909,7 +908,6 @@ describe('SchemaHelpers', () => {
           1,
           FIRST_CASE,
           OTHER_CASES,
-          undefined,
         ),
       ).toMatchSnapshot();
     });

--- a/playground/components/SplitWrapper.tsx
+++ b/playground/components/SplitWrapper.tsx
@@ -7,7 +7,6 @@ interface SplitWrapperProps {
 
 // react-split should be replaced with a React 18 friendly library or CSS
 const SplitWrapper = (props: SplitWrapperProps) => (
-  <>
     <Split
       style={{
         width: '100%',
@@ -29,7 +28,6 @@ const SplitWrapper = (props: SplitWrapperProps) => (
     >
       {props.children}
     </Split>
-  </>
 );
 
 export default SplitWrapper;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ... Removing the redundent use of the undefined keyword.
- ...
- ...

**Related issue(s)**
Resolves #1053 #1052 #1054
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
