### PR TITLE
fix: informative Stubs when document is invalid

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^3.0.24",
     "@asyncapi/openapi-schema-parser": "^3.0.24",
-    "@asyncapi/parser": "^3.1.0",
+    "@asyncapi/parser": "^3.3.0",
     "@asyncapi/protobuf-schema-parser": "^3.2.14",
     "highlight.js": "^10.7.2",
     "isomorphic-dompurify": "^2.14.0",

--- a/library/src/containers/AsyncApi/Standalone.tsx
+++ b/library/src/containers/AsyncApi/Standalone.tsx
@@ -75,7 +75,13 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
       if (!error) {
         return null;
       }
-      return concatenatedConfig.show?.errors && <Error error={error} />;
+      return (
+        concatenatedConfig.show?.errors && (
+          <section className="aui-root">
+            <Error error={error} />
+          </section>
+        )
+      );
     }
 
     return (

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -14,7 +14,11 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
         return null;
       }
       return (
-        <div key={index} className="flex gap-2">
+        <div
+          key={index}
+          className="flex gap-2"
+        >
+          <span>{`line ${singleError?.location?.startLine}:`}</span>
           <code className="whitespace-pre-wrap break-all ml-2">
             {singleError.title}
           </code>

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -14,11 +14,8 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
         return null;
       }
       return (
-        <div
-          key={index}
-          className="flex gap-2"
-        >
-          <span>{`line ${singleError?.location?.startLine}:`}</span>
+        <div key={index} className="flex gap-2">
+          <span>{`line ${singleError?.location?.startLine + singleError?.location?.startOffset}:`}</span>
           <code className="whitespace-pre-wrap break-all ml-2">
             {singleError.title}
           </code>

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -15,8 +15,6 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
       }
       return (
         <div key={index} className="flex gap-2">
-          {/* <span>{`${singleError?.location?.startLine}.${singleError?.location?.startColumn}`}</span> */}
-          {/* <span> </span> */}
           <code className="whitespace-pre-wrap break-all ml-2">
             {singleError.title}
           </code>

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -10,12 +10,13 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
 
   return errors
     .map((singleError: ValidationError, index: number) => {
-      if (!singleError?.title || !singleError.location) {
+      if (!singleError?.title) {
         return null;
       }
       return (
-        <div key={index} className="flex">
-          <span>{`${singleError.location.startLine}.`}</span>
+        <div key={index} className="flex gap-2">
+          {/* <span>{`${singleError?.location?.startLine}.${singleError?.location?.startColumn}`}</span> */}
+          {/* <span> </span> */}
           <code className="whitespace-pre-wrap break-all ml-2">
             {singleError.title}
           </code>

--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -29,7 +29,7 @@ export class Parser {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const parseResult = await asyncapiParser.parse(content, parserOptions);
 
-      let error: {
+      const error: {
         title: string | undefined;
         validationErrors: ValidationError[] | undefined;
       } = {
@@ -39,6 +39,7 @@ export class Parser {
 
       if (parseResult.document === undefined) {
         parseResult.diagnostics.forEach((diagnostic) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
           if (diagnostic.severity == 0) {
             const tempObj: ValidationError = {
               title: diagnostic.message,
@@ -46,7 +47,8 @@ export class Parser {
                 jsonPointer: '/' + diagnostic.path.join('/'),
                 startLine: diagnostic.range.start.line,
                 startColumn: diagnostic.range.start.character,
-                startOffset: 0,
+                // as of @asyncapi/parser 3.3.0 offset of 1 correctly shows the error line
+                startOffset: 1,
                 endLine: diagnostic.range.end.line,
                 endColumn: diagnostic.range.end.character,
                 endOffset: 0,

--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -40,10 +40,10 @@ export class Parser {
       if (parseResult.document === undefined) {
         parseResult.diagnostics.forEach((diagnostic) => {
           if (diagnostic.severity == 0) {
-            const tempObj:ValidationError = {
+            const tempObj: ValidationError = {
               title: diagnostic.message,
               location: {
-                jsonPointer: 'json pointer',
+                jsonPointer: '/' + diagnostic.path.join('/'),
                 startLine: diagnostic.range.start.line,
                 startColumn: diagnostic.range.start.character,
                 startOffset: 0,

--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -40,7 +40,7 @@ export class Parser {
       if (parseResult.document === undefined) {
         parseResult.diagnostics.forEach((diagnostic) => {
           if (diagnostic.severity == 0) {
-            const tempObj = {
+            const tempObj:ValidationError = {
               title: diagnostic.message,
               location: {
                 jsonPointer: 'json pointer',
@@ -52,7 +52,7 @@ export class Parser {
                 endOffset: 0,
               },
             };
-            error.validationErrors?.push(tempObj as unknown as ValidationError);
+            error.validationErrors?.push(tempObj);
           }
         });
         throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",
         "@asyncapi/openapi-schema-parser": "^3.0.24",
-        "@asyncapi/parser": "^3.1.0",
+        "@asyncapi/parser": "^3.3.0",
         "@asyncapi/protobuf-schema-parser": "^3.2.14",
         "highlight.js": "^10.7.2",
         "isomorphic-dompurify": "^2.14.0",
@@ -190,23 +190,23 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.1.0.tgz",
-      "integrity": "sha512-rUd+fsPRE68o+F3gLqk7OaBj5J5VgBiLk9eJBGEXolNmKbVd45mxJm2aBpMkphQEmYHuBvxZyiNYlSCyr1D2fA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.3.0.tgz",
+      "integrity": "sha512-IqBeDU/YxiHP/ySPYR5ayT/EE2ad9V75v8lhcA2ZowRDKh1YvNJaDwTpJjmRuggg8328uSDc9x/YEy6KgRgcgw==",
       "dependencies": {
-        "@asyncapi/specs": "^6.7.1",
+        "@asyncapi/specs": "^6.8.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
+        "@stoplight/json": "3.21.0",
         "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-core": "^1.18.3",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
         "@stoplight/spectral-ref-resolver": "^1.0.3",
         "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
+        "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
@@ -230,9 +230,9 @@
       "link": true
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.7.1.tgz",
-      "integrity": "sha512-jEaW2vgAwD9GboCdO/TI1zN2k+iowL8YFYwiZwTIr4U4KDmsgo3BLypScl6Jl4+IvY9RdsWE67nuzVX7jooiqQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.8.0.tgz",
+      "integrity": "sha512-1i6xs8+IOh6U5T7yH+bCMGQBF+m7kP/NpwyAlt++XaDQutoGCgACf24mQBgcDVqDWWoY81evQv+9ABvw0BviVg==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -6414,14 +6414,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -11713,6 +11713,11 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
       "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -26463,6 +26468,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }


### PR DESCRIPTION
**Description**
Diagnostics with severity 0 are displayed as errors.

Before 
(Invalid document 👇 with syntax error)
![image](https://github.com/user-attachments/assets/028baede-9b67-4c10-9c87-40817dc6ce65)


After
(Invalid document 👇 with syntax error)
![image](https://github.com/user-attachments/assets/368050f9-2bf3-49f2-b27c-139815f98d2c)

(document with spec specific errors 👇)
![image](https://github.com/user-attachments/assets/e4f9bd2b-6758-431e-9b4a-2b6723ec3895)


**Related Issue**
 #1048 
#874 
