### PR TITLE
fix: ensure tabIndex is a number before proceeding in condition

### DIFF
--- a/playground/components/Tab.tsx
+++ b/playground/components/Tab.tsx
@@ -19,7 +19,7 @@ class Tab extends Component<TabProps> {
         <TabLink
           onClick={(event) => {
             event.preventDefault();
-            if (parentCallback && tabIndex) {
+            if (parentCallback && typeof tabIndex === 'number') {
               parentCallback(tabIndex);
             }
           }}


### PR DESCRIPTION
**Description**
Checking tabIndex is a number instead of checking if tabIndex is falsy or truthy  

**Related issue(s)**
#1069 