### PR TITLE
feat: fix of make @asyncapi/react component with vs asyncapi preview

### DIFF
--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -1,4 +1,9 @@
-import { Parser as AsyncapiParser, fromURL } from '@asyncapi/parser';
+import {
+  Parser as AsyncapiParser,
+  Diagnostic,
+  DiagnosticSeverity,
+  fromURL,
+} from '@asyncapi/parser';
 import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
 import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
@@ -27,40 +32,16 @@ export class Parser {
   ): Promise<ParserReturn> {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const parseResult = await asyncapiParser.parse(content, parserOptions);
+      const { document, diagnostics } = await asyncapiParser.parse(
+        content,
+        parserOptions,
+      );
 
-      const error: {
-        title: string | undefined;
-        validationErrors: ValidationError[] | undefined;
-      } = {
-        title: 'There are errors in your Asyncapi document',
-        validationErrors: [],
-      };
-
-      if (parseResult.document === undefined) {
-        parseResult.diagnostics.forEach((diagnostic) => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-          if (diagnostic.severity == 0) {
-            const tempObj: ValidationError = {
-              title: diagnostic.message,
-              location: {
-                jsonPointer: '/' + diagnostic.path.join('/'),
-                startLine: diagnostic.range.start.line,
-                startColumn: diagnostic.range.start.character,
-                // as of @asyncapi/parser 3.3.0 offset of 1 correctly shows the error line
-                startOffset: 1,
-                endLine: diagnostic.range.end.line,
-                endColumn: diagnostic.range.end.character,
-                endOffset: 0,
-              },
-            };
-            error.validationErrors?.push(tempObj);
-          }
-        });
-        throw error;
+      if (document === undefined) {
+        throw this.convertDiagnosticToErrorObject(diagnostics, [0]);
       }
 
-      return { asyncapi: parseResult.document };
+      return { asyncapi: document };
     } catch (err) {
       return this.handleError(err as ErrorObject);
     }
@@ -79,12 +60,50 @@ export class Parser {
         arg.requestOptions as any,
       );
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const { document } = await fromResult.parse(parserOptions);
-      return { asyncapi: document };
+      const { document, diagnostics } = await fromResult.parse(parserOptions);
+
+      if (document == undefined) {
+        // this means there are errors in the document.
+        // so we gather all the severity 0 diagnostics and throw them as errors
+        throw this.convertDiagnosticToErrorObject(diagnostics, [0]);
+      }
+
+      return { asyncapi: document, error: undefined };
     } catch (err) {
       return this.handleError(err as ErrorObject);
     }
   }
+
+  static readonly convertDiagnosticToErrorObject = (
+    diagnostics: Diagnostic[],
+    severities: DiagnosticSeverity[],
+  ): ErrorObject => {
+    const error: ErrorObject = {
+      title: 'There are errors in your Asyncapi document',
+      type: 'VALIDATION_ERRORS_TYPE',
+      validationErrors: [],
+    };
+    diagnostics.forEach((diagnostic) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+      if (severities.includes(diagnostic.severity)) {
+        const tempObj: ValidationError = {
+          title: diagnostic.message,
+          location: {
+            jsonPointer: '/' + diagnostic.path.join('/'),
+            startLine: diagnostic.range.start.line,
+            startColumn: diagnostic.range.start.character,
+            // as of @asyncapi/parser 3.3.0 offset of 1 correctly shows the error line
+            startOffset: 1,
+            endLine: diagnostic.range.end.line,
+            endColumn: diagnostic.range.end.character,
+            endOffset: 0,
+          },
+        };
+        error.validationErrors?.push(tempObj);
+      }
+    });
+    return error;
+  };
 
   private static handleError = (err: ErrorObject): ParserReturn => {
     if (err.type === VALIDATION_ERRORS_TYPE) {

--- a/library/src/helpers/parser.ts
+++ b/library/src/helpers/parser.ts
@@ -31,9 +31,10 @@ export class Parser {
     parserOptions?: any,
   ): Promise<ParserReturn> {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const { document, diagnostics } = await asyncapiParser.parse(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         content,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         parserOptions,
       );
 


### PR DESCRIPTION
**Description**
Improved the error handling in `helpers/parser` to convert diagnostics of severity 0 into errors which can be displayed.

This pr is almost same to #1068. It just targets different kind of parsing. ie `parseFromUrl` method which is used when inside of  vs-asyncapi-preview extension.

These are the following changes it does to the vs-asyncapi-preview extension.

Before
![image](https://github.com/user-attachments/assets/5ea93a29-3d41-4cb6-888d-51e0dd55921e)

After
![image](https://github.com/user-attachments/assets/65802e5c-a8b8-4ce4-ac32-7a6d65cc8f0b)

**Related issue(s)**
#1077 
and
[https://github.com/asyncapi/vs-asyncapi-preview/issues/200](https://github.com/asyncapi/vs-asyncapi-preview/issues/200)