### PR TITLE
feat: title added for externalDoc.description

### DIFF
--- a/library/src/containers/Info/Info.tsx
+++ b/library/src/containers/Info/Info.tsx
@@ -73,7 +73,10 @@ export const Info: React.FunctionComponent = () => {
               </li>
             )}
             {externalDocs && (
-              <li className="inline-block mt-2 mr-2">
+              <li
+                title={externalDocs.description()}
+                className="inline-block mt-2 mr-2"
+              >
                 <Href
                   className="border border-solid border-orange-300 hover:bg-orange-300 hover:text-orange-600 text-orange-500 font-bold no-underline text-xs uppercase rounded px-3 py-1"
                   href={externalDocs.url()}


### PR DESCRIPTION
**Description**
A simple one line `title` attribute for `externalDocs.description` to show a tool-tip of the description.
Just like how `tag.description` have it.

BEFORE:
https://github.com/user-attachments/assets/86ec4e73-3401-463b-884e-46abbffa182a

AFTER:
https://github.com/user-attachments/assets/f2749f6c-2266-409b-a206-01e4ece3db0e

**Related issue(s)**
 #1084