### PR TITLE
fix: fragment navigation issue fix

### DIFF
--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -53,7 +53,7 @@ export const Operation: React.FunctionComponent<Props> = (props) => {
               {servers.map((server) => (
                 <li className="inline-block mt-2 mr-2" key={server.id()}>
                   <a
-                    href={`#${CommonHelpers.getIdentifier(
+                    href={`${window.location.pathname}#${CommonHelpers.getIdentifier(
                       'server-' + server.id(),
                       config,
                     )}`}
@@ -406,7 +406,7 @@ export const OperationReplyChannelInfo: React.FunctionComponent<Props> = ({
             {servers.map((server) => (
               <li className="inline-block mt-2 mr-2" key={server.id()}>
                 <a
-                  href={`#${CommonHelpers.getIdentifier(
+                  href={`${window.location.pathname}#${CommonHelpers.getIdentifier(
                     'server-' + server.id(),
                     config,
                   )}`}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
Fixed the issue by using window.location.pathname in the href attribute, so that full URL (current path + fragment) is generated when clicking on server links.

**Related issue(s)**
Fixes #1097 