### PR TITLE
refactor: added consistent styling for buttons and tags

### DIFF
--- a/library/src/components/Schema.tsx
+++ b/library/src/components/Schema.tsx
@@ -209,7 +209,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                 {schema.default() !== undefined && (
                   <div className="text-xs">
                     Default value:
-                    <span className="border inline-block text-orange-600 rounded ml-1 py-0 px-2">
+                    <span className="inline-block bg-orange-600 text-white rounded ml-1 py-0 px-2">
                       {SchemaHelpers.prettifyValue(schema.default())}
                     </span>
                   </div>
@@ -217,7 +217,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                 {schema.const() !== undefined && (
                   <div className="text-xs">
                     Const:
-                    <span className="border inline-block text-orange-600 rounded ml-1 py-0 px-2">
+                    <span className="inline-block bg-orange-600 text-white rounded ml-1 py-0 px-2">
                       {SchemaHelpers.prettifyValue(schema.const())}
                     </span>
                   </div>
@@ -228,7 +228,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                     {schema.enum()?.map((e, idx) => (
                       <li
                         key={idx}
-                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2"
+                        className="inline-block bg-orange-600 text-white rounded ml-1 py-0 px-2"
                       >
                         <span>{SchemaHelpers.prettifyValue(e)}</span>
                       </li>
@@ -259,7 +259,7 @@ export const Schema: React.FunctionComponent<Props> = ({
                     {schema.examples()?.map((e, idx) => (
                       <li
                         key={idx}
-                        className="border inline-block text-orange-600 rounded ml-1 py-0 px-2 break-all"
+                        className="inline-block bg-orange-600 text-white rounded ml-1 py-0 px-2 break-all"
                       >
                         <span>{SchemaHelpers.prettifyValue(e)}</span>
                       </li>

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -91,7 +91,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Message ID
-                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2">
                   {messageId}
                 </span>
               </div>
@@ -102,7 +102,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Correlation ID
-                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2 bg-orange-300">
                   {correlationId.location()}
                 </span>
               </div>

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -91,7 +91,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Message ID
-                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2">
                   {messageId}
                 </span>
               </div>
@@ -102,7 +102,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Correlation ID
-                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2">
                   {correlationId.location()}
                 </span>
               </div>

--- a/library/src/containers/Messages/Message.tsx
+++ b/library/src/containers/Messages/Message.tsx
@@ -91,7 +91,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Message ID
-                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2">
+                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
                   {messageId}
                 </span>
               </div>
@@ -102,7 +102,7 @@ export const Message: React.FunctionComponent<Props> = ({
             <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
               <div className="text-sm text-gray-700">
                 Correlation ID
-                <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2 bg-orange-300">
+                <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
                   {correlationId.location()}
                 </span>
               </div>

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -70,7 +70,7 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
             className: 'fill-current text-gray-200',
           }}
         >
-          <span className="inline-block w-20 py-0.5 mr-1 bg-gray-200 text-sm text-center rounded focus:outline-none">
+          <span className="inline-block w-20 py-0.5 mr-1 text-gray-200 text-sm border text-center rounded focus:outline-none">
             {type}
           </span>
         </CollapseButton>

--- a/library/src/containers/Messages/MessageExample.tsx
+++ b/library/src/containers/Messages/MessageExample.tsx
@@ -70,7 +70,7 @@ export const Example: React.FunctionComponent<ExampleProps> = ({
             className: 'fill-current text-gray-200',
           }}
         >
-          <span className="inline-block w-20 py-0.5 mr-1 text-gray-200 text-sm border text-center rounded focus:outline-none">
+          <span className="inline-block w-20 py-0.5 mr-1 bg-gray-200 text-sm text-center rounded focus:outline-none">
             {type}
           </span>
         </CollapseButton>

--- a/library/src/containers/Operations/Operation.tsx
+++ b/library/src/containers/Operations/Operation.tsx
@@ -170,7 +170,7 @@ export const OperationInfo: React.FunctionComponent<Props> = (props) => {
   const specV = useSpec().version();
   const version = specV.localeCompare('2.6.0', undefined, { numeric: true });
   const isAsyncAPIv2 = version === 0;
-  const { borderColor, typeLabel } =
+  const { backgroundColor, typeLabel } =
     CommonHelpers.getOperationDesignInformation({
       type,
       config,
@@ -181,7 +181,7 @@ export const OperationInfo: React.FunctionComponent<Props> = (props) => {
       <div className="mb-4">
         <h3>
           <span
-            className={`font-mono border uppercase p-1 rounded mr-2 ${borderColor}`}
+            className={`font-mono text-white uppercase p-1 rounded mr-2 ${backgroundColor}`}
             title={type}
           >
             {typeLabel}
@@ -223,7 +223,7 @@ export const OperationInfo: React.FunctionComponent<Props> = (props) => {
         <div className="border bg-gray-100 rounded px-4 py-2 mt-2">
           <div className="text-sm text-gray-700">
             Operation ID
-            <span className="border text-orange-600 rounded text-xs ml-2 py-0 px-2">
+            <span className="bg-orange-600 text-white rounded text-xs ml-2 py-0 px-2">
               {operationId}
             </span>
           </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR is related to the issue with inconsistent styling. According to the issue, "WCAG 2.0 guideline 3.2.4 Consistent Identification states "Components that have the same functionality within a set of Web pages are identified consistently". 

For example:
If we move to [async-react website](https://asyncapi.github.io/asyncapi-react/),
<img width="871" alt="Screenshot 2024-10-20 at 3 12 13 AM" src="https://github.com/user-attachments/assets/7ade1005-a7b5-495c-92d0-809319673453">
We will notice that there are multiple elements with a solid color background, but only some of them are a button.

Changes proposed in this pull request:

To resolve this, the ask in the issue was:
1. Buttons to be styled with rectangular outline.
2. Tags to be styled with solid background.

In this PR, changes have been made in 4 files:

1. **In "library/src/components/Schema.tsx" file:**
   Addresses the tags "Default values", "const", "Allowed values", "Example values".
   BEFORE:
   <img width="1203" alt="Screenshot 2024-10-20 at 3 30 26 AM" src="https://github.com/user-attachments/assets/6dec1312-1d16-4278-8428-d6cb510fa3ae">

   
   AFTER:
   <img width="1203" alt="Screenshot 2024-10-20 at 3 30 08 AM" src="https://github.com/user-attachments/assets/05236164-3725-4bb3-9513-505e20a43800">

2. **In "library/src/containers/Messages/Message.tsx" file**
    Addresses tags of "Correlation Id" and "Message Id"
   BEFORE:
   <img width="1203" alt="Screenshot 2024-10-20 at 3 32 54 AM" src="https://github.com/user-attachments/assets/0023fadb-1954-4304-9c24-ad389a0c506b">
   AFTER:
   
<img width="1203" alt="Screenshot 2024-10-20 at 3 33 28 AM" src="https://github.com/user-attachments/assets/e44e6277-6720-4a32-bb5c-e55a6bb63891">

3. **In "library/src/containers/Messages/MessageExample.tsx" file**
    Addresses the example labels
    BEFORE:
    <img width="1203" alt="Screenshot 2024-10-20 at 3 35 03 AM" src="https://github.com/user-attachments/assets/3c3fb780-523d-4713-b297-c97ba8cd901f">

    AFTER:
    
   <img width="1203" alt="Screenshot 2024-10-20 at 3 35 32 AM" src="https://github.com/user-attachments/assets/44640bcd-680f-4003-9199-a5554c10f7bc">

4. In "library/src/containers/Operations/Operation.tsx" file
    BEFORE:
    <img width="1203" alt="Screenshot 2024-10-20 at 3 36 44 AM" src="https://github.com/user-attachments/assets/e0162bf4-be3b-47af-8086-1e2a85a1ff44">

    AFTER:
    
    <img width="824" alt="Screenshot 2024-10-20 at 3 37 20 AM" src="https://github.com/user-attachments/assets/4568e771-099d-4468-88a3-cf0f3194e663">
   
   <img width="824" alt="Screenshot 2024-10-20 at 3 37 44 AM" src="https://github.com/user-attachments/assets/07771708-4cad-4828-884d-5556097a9bf8">











**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #960 