### PR TITLE
feat: error boundary in layout to handle application errors / crashes

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -76,6 +76,7 @@
     "isomorphic-dompurify": "^2.14.0",
     "marked": "^4.0.14",
     "openapi-sampler": "^1.2.1",
+    "react-error-boundary": "^4.1.2",
     "use-resize-observer": "^9.1.0"
   },
   "peerDependencies": {

--- a/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
+++ b/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
@@ -28,8 +28,7 @@ function fallbackRender({ error, resetErrorBoundary }: FallbackProps) {
 
 const AsyncApiErrorBoundary = ({ children }: Props) => {
   const onReset = (details: any) => {
-    // TODO: some magic to make monaco editor undo
-    console.log('resetting', details);
+    // TODO: maybe some magic to recover the previous document ( the one without the error ) automatically 
   };
 
   return (

--- a/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
+++ b/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ReactNode } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { ErrorObject } from '../../types';
 import { Error } from '../Error/Error';
 
@@ -8,33 +8,23 @@ interface Props {
   children: ReactNode;
 }
 
-interface FallbackProps {
-  error: any;
-  resetErrorBoundary?: (...args: any[]) => void;
-}
-
-function fallbackRender({ error, resetErrorBoundary }: FallbackProps) {
+function fallbackRender({ error }: FallbackProps) {
   const ErrorObject: ErrorObject = {
-    title: "Something went wrong",
+    title: 'Something went wrong',
     type: 'application-error',
-    validationErrors:[
+    validationErrors: [
       {
-        title:error.message,
-      }
-    ]
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        title: error?.message,
+      },
+    ],
   };
   return <Error error={ErrorObject} />;
 }
 
 const AsyncApiErrorBoundary = ({ children }: Props) => {
-  const onReset = (details: any) => {
-    // TODO: maybe some magic to recover the previous document ( the one without the error ) automatically 
-  };
-
   return (
-    <ErrorBoundary fallbackRender={fallbackRender} onReset={onReset}>
-      {children}
-    </ErrorBoundary>
+    <ErrorBoundary fallbackRender={fallbackRender}>{children}</ErrorBoundary>
   );
 };
 

--- a/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
+++ b/library/src/containers/ApplicationErrorHandler/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorObject } from '../../types';
+import { Error } from '../Error/Error';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface FallbackProps {
+  error: any;
+  resetErrorBoundary?: (...args: any[]) => void;
+}
+
+function fallbackRender({ error, resetErrorBoundary }: FallbackProps) {
+  const ErrorObject: ErrorObject = {
+    title: "Something went wrong",
+    type: 'application-error',
+    validationErrors:[
+      {
+        title:error.message,
+      }
+    ]
+  };
+  return <Error error={ErrorObject} />;
+}
+
+const AsyncApiErrorBoundary = ({ children }: Props) => {
+  const onReset = (details: any) => {
+    // TODO: some magic to make monaco editor undo
+    console.log('resetting', details);
+  };
+
+  return (
+    <ErrorBoundary fallbackRender={fallbackRender} onReset={onReset}>
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default AsyncApiErrorBoundary;

--- a/library/src/containers/AsyncApi/Layout.tsx
+++ b/library/src/containers/AsyncApi/Layout.tsx
@@ -13,6 +13,7 @@ import { Error } from '../Error/Error';
 import { ConfigInterface } from '../../config';
 import { SpecificationContext, ConfigContext } from '../../contexts';
 import { ErrorObject } from '../../types';
+import AsyncApiErrorBoundary from '../ApplicationErrorHandler/ErrorBoundary';
 
 interface Props {
   asyncapi: AsyncAPIDocumentInterface;
@@ -48,24 +49,26 @@ const AsyncApiLayout: React.FunctionComponent<Props> = ({
     <ConfigContext.Provider value={config}>
       <SpecificationContext.Provider value={asyncapi}>
         <section className="aui-root">
-          <div
-            className={`${observerClassName} relative md:flex bg-white leading-normal`}
-            id={config.schemaID ?? undefined}
-            ref={ref}
-          >
-            {configShow.sidebar && <Sidebar />}
-            <div className="panel--center relative py-8 flex-1">
-              <div className="relative z-10">
-                {configShow.errors && error && <Error error={error} />}
-                {configShow.info && <Info />}
-                {configShow.servers && <Servers />}
-                {configShow.operations && <Operations />}
-                {configShow.messages && <Messages />}
-                {configShow.schemas && <Schemas />}
+          <AsyncApiErrorBoundary>
+            <div
+              className={`${observerClassName} relative md:flex bg-white leading-normal`}
+              id={config.schemaID ?? undefined}
+              ref={ref}
+            >
+              {configShow.sidebar && <Sidebar />}
+              <div className="panel--center relative py-8 flex-1">
+                <div className="relative z-10">
+                  {configShow.errors && error && <Error error={error} />}
+                  {configShow.info && <Info />}
+                  {configShow.servers && <Servers />}
+                  {configShow.operations && <Operations />}
+                  {configShow.messages && <Messages />}
+                  {configShow.schemas && <Schemas />}
+                </div>
+                <div className="panel--right absolute top-0 right-0 h-full bg-gray-800" />
               </div>
-              <div className="panel--right absolute top-0 right-0 h-full bg-gray-800" />
             </div>
-          </div>
+          </AsyncApiErrorBoundary>
         </section>
       </SpecificationContext.Provider>
     </ConfigContext.Provider>

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -15,7 +15,7 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
       }
       return (
         <div key={index} className="flex gap-2">
-          {(singleError?.location?.startLine ||
+          {(singleError?.location?.startLine ??
             singleError?.location?.startOffset) && (
             <span>{`line ${singleError?.location?.startLine + singleError?.location?.startOffset}:`}</span>
           )}

--- a/library/src/containers/Error/Error.tsx
+++ b/library/src/containers/Error/Error.tsx
@@ -15,7 +15,10 @@ const renderErrors = (errors: ValidationError[]): React.ReactNode => {
       }
       return (
         <div key={index} className="flex gap-2">
-          <span>{`line ${singleError?.location?.startLine + singleError?.location?.startOffset}:`}</span>
+          {(singleError?.location?.startLine ||
+            singleError?.location?.startOffset) && (
+            <span>{`line ${singleError?.location?.startLine + singleError?.location?.startOffset}:`}</span>
+          )}
           <code className="whitespace-pre-wrap break-all ml-2">
             {singleError.title}
           </code>

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -44,7 +44,7 @@ export interface MessageExample {
 
 export interface ValidationError {
   title: string;
-  location: {
+  location?: {
     jsonPointer: string;
     startLine: number;
     startColumn: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "isomorphic-dompurify": "^2.14.0",
         "marked": "^4.0.14",
         "openapi-sampler": "^1.2.1",
+        "react-error-boundary": "^4.1.2",
         "use-resize-observer": "^9.1.0"
       },
       "devDependencies": {
@@ -21999,6 +22000,18 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.1.2.tgz",
+      "integrity": "sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
**Description**
As proposed and discussed here https://github.com/asyncapi/asyncapi-react/pull/1101#issuecomment-2462910610.

Changes proposed in this pull request:
1. Added an [error boundary](https://github.com/bvaughn/react-error-boundary) in layout to handle errors generated by infinite recursion and such so that the application doesnt crash into an irrecoverable state.

2. Reused the already existing Error component to render error,

**Related issue(s)**
https://github.com/asyncapi/asyncapi-react/issues/1100