### PR TITLE
fix Sidebar.tsx

### DIFF
--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -39,9 +39,10 @@ export const Sidebar: React.FunctionComponent = () => {
       <ul className="text-sm mt-2">
         {messages.map((message, index) => (
           <li key={`menu-message-list-${message.name() ?? index}`}>
+          // fixed the href message.name() to message.id() to fix undifined name 
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
-              href={`#message-${message.name()}`}
+              href={`#message-${message.id()}`}
               onClick={() => setShowSidebar(false)}
             >
               <div className="break-all inline-block">{message.id()}</div>


### PR DESCRIPTION
fixed this issue #1109

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The anchor link for a message in the sidebar does not work as expected when message.name() and message.id() differ.

**Expected result**
Clicking on a message in the sidebar should set the correct hash in the URL and scroll the message into view.

Actual result
The anchor link only works if message.name() and message.id() are identical.
If message.name() is not provided, the hash becomes #message-undefined.

**before**
![image](https://github.com/user-attachments/assets/93b19ff6-da15-44e2-99e8-793d5af155ab)

**after**
![image](https://github.com/user-attachments/assets/05938372-97af-4fd4-97a9-8dae9142b19d)

