### PR TITLE
fix(sidebar): resolved sidebar hash URL navigation issue

### DIFF
--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -41,7 +41,7 @@ export const Sidebar: React.FunctionComponent = () => {
           <li key={`menu-message-list-${message.name() ?? index}`}>
             <a
               className="flex break-words no-underline text-gray-700 mt-2 hover:text-gray-900"
-              href={`#message-${message.name()}`}
+              href={`#message-${message.name() ?? message.id()}`}
               onClick={() => setShowSidebar(false)}
             >
               <div className="break-all inline-block">{message.id()}</div>


### PR DESCRIPTION
fixed this issue #1109 

Description

Changes proposed in this pull request:

The anchor link for a message in the sidebar does not work as expected when message.name() and message.id() differ.

Expected result
Clicking on a message in the sidebar should set the correct hash in the URL and scroll the message into view.

Actual result
The anchor link only works if message.name() and message.id() are identical.
If message.name() is not provided, the hash becomes #message-undefined.

before
![before](https://github.com/user-attachments/assets/be8271c6-f2ad-4233-b478-67a64d7e597c)

after
![after](https://github.com/user-attachments/assets/0d5236d8-a585-4b01-b6ea-c0cdd0449ed9)


Code changes required : 
<img width="721" alt="async-sidebar" src="https://github.com/user-attachments/assets/ccd9ab5e-3548-4d07-b6c8-ee417791ac51">

