### PR TITLE
fix: seperate messages/schema from operation in sidebar

### DIFF
--- a/library/src/containers/Sidebar/Sidebar.tsx
+++ b/library/src/containers/Sidebar/Sidebar.tsx
@@ -89,8 +89,6 @@ export const Sidebar: React.FunctionComponent = () => {
         </a>
         <OperationsList />
       </li>
-      {showMessages && messagesList}
-      {showSchemas && schemasList}
     </>
   );
 
@@ -161,6 +159,8 @@ export const Sidebar: React.FunctionComponent = () => {
                 </li>
               )}
               {operationList}
+              {showMessages && messagesList}
+              {showSchemas && schemasList}
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Messages and Schemas will always be displayed in the sidebar, regardless of whether an operation exists.

fixes: #1106 