### PR TITLE
fix!: update wc release workflow

### DIFF
--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -10,20 +10,27 @@ jobs:
   webcomponent:
     name: Release Web-component
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
           # in case release is created from release branch then we need to checkout from given branch
           # if @semantic-release/github is used to publish, the minimum version is 7.2.0 for proper working
           ref: ${{ github.event.release.target_commitish }}
-      - name: Check package-lock version
+      - name: Determine what node version to use
         uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
         id: lockversion
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
+          registry-url: "https://registry.npmjs.org"
           node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
@@ -42,18 +49,18 @@ jobs:
         run: VERSION=${{github.event.release.tag_name}} npm run bump:webcomp:version
       - name: Release web-component to NPM (@latest tag)
         if: github.event.release.target_commitish == 'master'
-        uses: JS-DevTools/npm-publish@5a85faf05d2ade2d5b6682bfe5359915d5159c6c # using 2.2.1 version https://github.com/JS-DevTools/npm-publish/releases/tag/v2.2.1
+        uses: JS-DevTools/npm-publish@1fe17a093199d8fabed85cbcc6f0f79eb06470da # using 4.1.0 version https://github.com/JS-DevTools/npm-publish/releases/tag/v4.1.0
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           package: ./web-component/package.json
           access: public
+          provenance: true
       - name: Release web-component to NPM (feature branch tag)
         if: github.event.release.target_commitish != 'master'
-        uses: JS-DevTools/npm-publish@5a85faf05d2ade2d5b6682bfe5359915d5159c6c # using 2.2.1 version https://github.com/JS-DevTools/npm-publish/releases/tag/v2.2.1
+        uses: JS-DevTools/npm-publish@1fe17a093199d8fabed85cbcc6f0f79eb06470da # using 4.1.0 version https://github.com/JS-DevTools/npm-publish/releases/tag/v4.1.0
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           package: ./web-component/package.json
           access: public
+          provenance: true
           tag: github.event.release.target_commitish
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
@@ -70,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
           # in case release is created from release branch then we need to checkout from given branch
@@ -78,9 +85,11 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
       - name: Check package-lock version
         uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
         id: lockversion
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'


### PR DESCRIPTION
This PR updates the release workflow for `web-component` to use npm trusted publishing (OIDC) instead of classic npm tokens, improving security and preparing for the upcoming deprecation of classic tokens. 