### PR TITLE
fix(react): cache event handler references for proper cleanup (#1235)

### DIFF
--- a/library/src/containers/AsyncApi/Standalone.tsx
+++ b/library/src/containers/AsyncApi/Standalone.tsx
@@ -28,6 +28,7 @@ interface AsyncAPIState {
 class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
   private readonly registeredPlugins = new Set<string>();
   private readonly propsPlugins = new Set<string>();
+  private readonly eventHandlers = new Map<string, (data: unknown) => void>();
 
   state: AsyncAPIState = {
     asyncapi: undefined,
@@ -125,11 +126,15 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
     );
   }
 
-  private handler(eventName: string) {
-    return (data: unknown) => {
-      this.props.onPluginEvent!(eventName, data);
-    };
+  private getEventHandler(eventName: string): (data: unknown) => void {
+    if (!this.eventHandlers.has(eventName)) {
+      this.eventHandlers.set(eventName, (data: unknown) => {
+        this.props.onPluginEvent!(eventName, data);
+      });
+    }
+    return this.eventHandlers.get(eventName)!;
   }
+
   private setupEventListeners() {
     const { onPluginEvent } = this.props;
     const { pm } = this.state;
@@ -137,14 +142,14 @@ class AsyncApiComponent extends Component<AsyncApiProps, AsyncAPIState> {
     if (!onPluginEvent) return;
 
     PLUGINEVENTS.forEach((event) => {
-      pm?.on(event, this.handler(event));
+      pm?.on(event, this.getEventHandler(event));
     });
   }
 
   private cleanupEventListeners() {
     const { pm } = this.state;
     PLUGINEVENTS.forEach((event) => {
-      pm?.off(event, this.handler(event));
+      pm?.off(event, this.getEventHandler(event));
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13775,7 +13775,8 @@
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gulp-header": {
       "version": "1.8.12",
@@ -19459,6 +19460,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -24260,7 +24262,8 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -28076,7 +28079,7 @@
         "@codemirror/lang-yaml": "^6.0.0",
         "@uiw/codemirror-theme-material": "^4.21.24",
         "@uiw/react-codemirror": "^4.21.24",
-        "next": "^16.1.7",
+        "next": "16.1.7",
         "react": "^18",
         "react-dom": "^18",
         "react-split": "^2.0.14",


### PR DESCRIPTION
## Problem

**Fixes #1235**

Event listeners registered via `pm.on()` are never properly removed by `pm.off()` because each call to `setupEventListeners()` creates new function references.

### Root Cause

```typescript
// BEFORE (broken):
private handler(eventName: string) {
  return (data: unknown) => {   // ← new function every call!
    this.props.onPluginEvent!(eventName, data);
  };
}

// setupEventListeners calls: pm.on('event', this.handler('event')) → fn#1
// cleanupEventListeners calls: pm.off('event', this.handler('event')) → fn#2
// fn#2 !== fn#1, so pm.off() cannot find and remove the listener
```

### Impact

- **Duplicate events**: Every component re-render adds more listeners
- **Memory leak**: Old listeners are never garbage collected
- **pm.off() is a no-op**: Cleanup code appears to work but does nothing

## Fix

Cache handler functions in a `Map<string, Function>` so the same reference is always used:

```typescript
// AFTER (fixed):
private readonly eventHandlers = new Map<string, (data: unknown) => void>();

private getEventHandler(eventName: string): (data: unknown) => void {
  if (!this.eventHandlers.has(eventName)) {
    this.eventHandlers.set(eventName, (data: unknown) => {
      this.props.onPluginEvent!(eventName, data);
    });
  }
  return this.eventHandlers.get(eventName)!;
}
```

Now `pm.on(event, getEventHandler(event))` and `pm.off(event, getEventHandler(event))` receive identical function references.

## Testing

- ✅ All 177 unit tests pass
- ✅ No behavior change — same events fired with same data
- ✅ Handlers cached per event name for component lifetime