### PR TITLE
docs: readd myself as owner in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the "@asyncapi/asyncapi-react" repository. The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @magicmatatjahu @asyncapi-bot-eve @AceTheCreator
+* @magicmatatjahu @asyncapi-bot-eve @AceTheCreator @catosaurusrex2003


### PR DESCRIPTION
I was added as owner in https://github.com/asyncapi/asyncapi-react/pull/1263

but accidentally got removed in https://github.com/asyncapi/asyncapi-react/pull/1264