### PR TITLE
fix: add node_auth for npm release fallback

### DIFF
--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -63,7 +63,7 @@ jobs:
           provenance: true
           tag: ${{ github.event.release.target_commitish }}
         env:
-         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -61,7 +61,9 @@ jobs:
           package: ./web-component/package.json
           access: public
           provenance: true
-          tag: github.event.release.target_commitish
+          tag: ${{ github.event.release.target_commitish }}
+        env:
+         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Add a fallback for failing trusted publishing on the web-component release workflow.

cc @catosaurusrex2003 