### PR TITLE
chore(fix): use token fall back for npm publishing in wc

### DIFF
--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -63,7 +63,7 @@ jobs:
           provenance: true
           tag: ${{ github.event.release.target_commitish }}
         env:
-         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -54,6 +54,7 @@ jobs:
           package: ./web-component/package.json
           access: public
           provenance: true
+          token: ${{ secrets.NPM_TOKEN }}
       - name: Release web-component to NPM (feature branch tag)
         if: github.event.release.target_commitish != 'master'
         uses: JS-DevTools/npm-publish@1fe17a093199d8fabed85cbcc6f0f79eb06470da # using 4.1.0 version https://github.com/JS-DevTools/npm-publish/releases/tag/v4.1.0
@@ -62,8 +63,7 @@ jobs:
           access: public
           provenance: true
           tag: ${{ github.event.release.target_commitish }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPM_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/release-wc-and-playground.yml
+++ b/.github/workflows/release-wc-and-playground.yml
@@ -61,7 +61,9 @@ jobs:
           package: ./web-component/package.json
           access: public
           provenance: true
-          tag: github.event.release.target_commitish
+          tag: ${{ github.event.release.target_commitish }}
+        env:
+         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
fixes: https://github.com/asyncapi/asyncapi-react/pull/1277