### PR TITLE
chore(release): bump package version to latest

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/react-component",
-  "version": "3.1.0",
+  "version": "3.1.3",
   "private": false,
   "description": "A React component for AsyncAPI specification.",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
     },
     "library": {
       "name": "@asyncapi/react-component",
-      "version": "3.1.0",
+      "version": "3.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",
@@ -13789,7 +13789,8 @@
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gulp-header": {
       "version": "1.8.12",
@@ -19474,6 +19475,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -24267,7 +24269,8 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -28250,10 +28253,10 @@
     },
     "web-component": {
       "name": "@asyncapi/web-component",
-      "version": "3.1.0",
+      "version": "3.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/react-component": "^3.1.0",
+        "@asyncapi/react-component": "^3.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "web-react-components": "^1.4.2"

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/web-component",
-  "version": "3.1.0",
+  "version": "3.1.3",
   "private": false,
   "description": "A web component for AsyncAPI specification. Based on @asyncapi/react-component.",
   "repository": {
@@ -44,7 +44,7 @@
     "install:reactcomp": "chmod +x ./bump-react-comp.sh && ./bump-react-comp.sh"
   },
   "dependencies": {
-    "@asyncapi/react-component": "^3.1.0",
+    "@asyncapi/react-component": "^3.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-react-components": "^1.4.2"


### PR DESCRIPTION
Version bump in package.json for release [v3.1.3](https://github.com/asyncapi/asyncapi-react/releases/tag/v3.1.3)