### PR TITLE
fix: fix-cypress-binary-windows

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -59,7 +59,7 @@
     "test:unit": "jest --detectOpenHandles",
     "test:unit:watch": "jest --detectOpenHandles --watch",
     "test:e2e:dev": "cypress run",
-    "test:e2e": "npm run build:standalone && cypress run",
+    "test:e2e": "npm run build:standalone && cypress install && cypress run",
     "prepare": "npm run build:dev",
     "prepublishOnly": "npm run prepack",
     "prepack": "npm run build:prod && cp ../README.md ./README.md && cp ../LICENSE ./LICENSE",


### PR DESCRIPTION
**Description**
The `windows-latest` jobs of both the release workflow (`if-nodejs-release.yml`) and PR testing (`if-nodejs-pr-testing.yml`) intermittently fail during npm test with:

The cypress npm package is installed, but the Cypress binary is missing.

The Cypress binary is normally downloaded by the cypress package's `postinstall` hook during `npm ci`. On Windows runners this download occasionally fails silently, `npm ci` still exits 0 (lifecycle script output is suppressed by default).

And the missing binary only surfaces later when cypress run starts. The failure is flaky, not deterministic: the same commit has passed and failed the Windows job within minutes of each other (e.g. runs 27759956186 vs 27760775611 on June 18).

**The Fix**
Add an explicit `cypress install` before cypress run in the test:e2e script:

Cypress install is the remedy Cypress itself suggests for this CI error (https://on.cypress.io/not-installed-ci-error).

It doesnt install the binary, when the binary is already present in the cache (the normal case on Linux/macOS), and downloads it only when the `postinstall` silently failed in windows, so it's safe on all three OS matrix jobs with no platform-specific handling.


**Related issue(s)**
https://github.com/asyncapi/.github/issues/407
